### PR TITLE
Fix opam dune version and add cmake as a build dependency

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -11,5 +11,6 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {build & >= "2.0" }
+  "dune" {>= "2.6"}
+  "conf-cmake" {build}
 ]

--- a/esy.json
+++ b/esy.json
@@ -13,5 +13,8 @@
   "dependencies": {
     "ocaml": "~4.9.0",
     "@opam/dune": "2.6.0"
+  },
+  "devDependencies": {
+    "@opam/conf-cmake": "*"
   }
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "207a5850ca39267a1865ede16b979772",
+  "checksum": "fb5e804ab5ae93eefa9eb0d3a4c57abc",
   "root": "binaryen.ml@link-dev:./esy.json",
   "node": {
     "ocaml@4.9.1000@d41d8cd9": {
@@ -25,7 +25,7 @@
       "dependencies": [
         "ocaml@4.9.1000@d41d8cd9", "@opam/dune@opam:2.6.0@3a9808e6"
       ],
-      "devDependencies": []
+      "devDependencies": [ "@opam/conf-cmake@opam:1@75ae6bc3" ]
     },
     "@opam/ocamlfind-secondary@opam:1.8.1@1afa38b2": {
       "id": "@opam/ocamlfind-secondary@opam:1.8.1@1afa38b2",
@@ -163,6 +163,23 @@
           "name": "conf-m4",
           "version": "1",
           "path": "esy.lock/opam/conf-m4.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "@opam/conf-cmake@opam:1@75ae6bc3": {
+      "id": "@opam/conf-cmake@opam:1@75ae6bc3",
+      "name": "@opam/conf-cmake",
+      "version": "opam:1",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-cmake",
+          "version": "1",
+          "path": "esy.lock/opam/conf-cmake.1"
         }
       },
       "overrides": [],

--- a/esy.lock/opam/conf-cmake.1/files/configure.sh
+++ b/esy.lock/opam/conf-cmake.1/files/configure.sh
@@ -1,0 +1,11 @@
+#/bin/bash -ex
+
+if command -v cmake3; then
+    cmake_cmd=cmake3
+elif command -v cmake; then
+    cmake_cmd=cmake
+else
+    exit 1
+fi
+
+echo "cmd: \"$cmake_cmd\"" >> conf-cmake.config

--- a/esy.lock/opam/conf-cmake.1/opam
+++ b/esy.lock/opam/conf-cmake.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kitware, Inc. and Contributors"
+homepage: "https://cmake.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "BSD-3-Clause"
+build: ["bash" "-ex" "configure.sh"]
+depexts: [
+  ["cmake"] {os-distribution = "homebrew" & os = "macos"}
+  ["cmake"] {os-distribution = "macports" & os = "macos"}
+  ["cmake"] {os-family = "debian"}
+  ["cmake3" "epel-release"] {os-distribution = "centos"}
+  ["cmake"] {os-distribution = "fedora"}
+  ["cmake"] {os-distribution = "alpine"}
+  ["cmake"] {os-distribution = "arch"}
+  ["cmake"] {os-family = "suse"}
+  ["cmake"] {os-distribution = "ol"}
+  ["dev-util/cmake"] {os-distribution = "gentoo"}
+  ["devel/cmake"] {os = "freebsd"}
+  ["devel/cmake"] {os = "openbsd"}
+  ["devel/cmake"] {os = "netbsd"}
+  ["devel/cmake"] {os = "dragonfly"}
+]
+synopsis: "Virtual package relying on cmake"
+description:
+  "This package can only install if cmake is installed on the system."
+extra-files: ["configure.sh" "md5=0cae8434c6b69725503c46525063c505"]
+flags: conf


### PR DESCRIPTION
This fixes the opam file via feedback from https://github.com/ocaml/opam-repository/pull/16637.