### PR TITLE
Add dune virtual interfaces

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(dirs :standard virtual)

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 2.6)
+
 (name binaryen)

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,3 @@
+(lang dune 2.6)
+
+(profile release)

--- a/src/dune
+++ b/src/dune
@@ -19,8 +19,9 @@
     (copy binaryen/lib/dllbinaryen.so dllbinaryen.so)))))
 
 (library
- (name binaryen)
- (public_name binaryen)
+ (name binaryen_native)
+ (public_name binaryen.native)
+ (implements binaryen)
  (foreign_stubs
   (language c)
   (names binaryen_stubs_types binaryen_stubs_ops binaryen_stubs_literals

--- a/test/dune
+++ b/test/dune
@@ -1,10 +1,8 @@
-(executable
+(test
  (name test)
- (libraries binaryen))
-
-(rule
- (alias runtest)
- (deps
-  (:< test.exe))
+ (modes
+  (best exe))
+ (libraries binaryen)
+ (modules test)
  (action
-  (run %{<})))
+  (run %{test})))

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,0 +1,10 @@
+OK!
+(module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (func $adder (param $0 i32) (param $1 i32) (result i32)
+  (i32.add
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+)

--- a/virtual/dune
+++ b/virtual/dune
@@ -1,0 +1,6 @@
+(library
+ (name binaryen)
+ (public_name binaryen)
+ (virtual_modules export expression features function function_table global
+   import literal memory module op type)
+ (default_implementation binaryen.native))

--- a/virtual/export.mli
+++ b/virtual/export.mli
@@ -1,0 +1,11 @@
+type t
+
+val add_function_export : Module.t -> string -> string -> t
+
+val add_table_export : Module.t -> string -> string -> t
+
+val add_memory_export : Module.t -> string -> string -> t
+
+val add_global_export : Module.t -> string -> string -> t
+
+val remove_export : Module.t -> string -> unit

--- a/virtual/expression.mli
+++ b/virtual/expression.mli
@@ -1,0 +1,63 @@
+type t
+
+val block : Module.t -> string -> t list -> t
+
+val if_ : Module.t -> t -> t -> t -> t
+
+val loop : Module.t -> string -> t -> t
+
+val break : Module.t -> string -> t -> t -> t
+
+val switch : Module.t -> string list -> string -> t -> t -> t
+
+val call : Module.t -> string -> t list -> Type.t -> t
+
+val call_indirect : Module.t -> t -> t list -> Type.t -> Type.t -> t
+
+val return_call : Module.t -> string -> t list -> Type.t -> t
+
+val return_call_indirect : Module.t -> t -> t list -> Type.t -> Type.t -> t
+
+val local_get : Module.t -> int -> Type.t -> t
+
+val local_set : Module.t -> int -> t -> t
+
+val local_tee : Module.t -> int -> t -> Type.t -> t
+
+val global_get : Module.t -> string -> Type.t -> t
+
+val global_set : Module.t -> string -> t -> t
+
+val load : Module.t -> int -> int -> int -> Type.t -> t -> t
+
+val store : Module.t -> int -> int -> int -> t -> t -> Type.t -> t
+
+val const : Module.t -> Literal.t -> t
+
+val unary : Module.t -> Op.t -> t -> t
+
+val binary : Module.t -> Op.t -> t -> t -> t
+
+val select : Module.t -> t -> t -> t -> t
+
+val drop : Module.t -> t -> t
+
+val return : Module.t -> t -> t
+
+val nop : Module.t -> t
+
+val unreachable : Module.t -> t
+
+val memory_copy : Module.t -> t -> t -> t -> t
+
+val memory_fill : Module.t -> t -> t -> t -> t
+
+val tuple_make : Module.t -> t list -> t
+
+val tuple_extract : Module.t -> t -> int -> t
+
+val pop : Module.t -> Type.t -> t
+
+val null : unit -> t
+
+val print : t -> unit

--- a/virtual/features.mli
+++ b/virtual/features.mli
@@ -1,0 +1,23 @@
+val mvp : int
+
+val atomics : int
+
+val bulk_memory : int
+
+val mutable_globals : int
+
+val nontrapping_fp_to_int : int
+
+val sign_ext : int
+
+val simd128 : int
+
+val exception_handling : int
+
+val tail_call : int
+
+val reference_types : int
+
+val multivalue : int
+
+val all : int

--- a/virtual/function.mli
+++ b/virtual/function.mli
@@ -1,0 +1,14 @@
+type t
+
+val add_function :
+  Module.t -> string -> Type.t -> Type.t -> Type.t array -> Expression.t -> t
+
+val set_start : Module.t -> t -> unit
+
+val set_debug_location : t -> Expression.t -> int -> int -> int -> unit
+
+val get_function : Module.t -> string -> t
+
+val remove_function : Module.t -> string -> unit
+
+val get_num_functions : Module.t -> int

--- a/virtual/function_table.mli
+++ b/virtual/function_table.mli
@@ -1,0 +1,2 @@
+val set_function_table :
+  Module.t -> int -> int -> string list -> Expression.t -> unit

--- a/virtual/global.mli
+++ b/virtual/global.mli
@@ -1,0 +1,7 @@
+type t
+
+val add_global : Module.t -> string -> Type.t -> bool -> Expression.t -> t
+
+val get_global : Module.t -> string -> t
+
+val remove_global : Module.t -> string -> unit

--- a/virtual/import.mli
+++ b/virtual/import.mli
@@ -1,0 +1,9 @@
+val add_function_import :
+  Module.t -> string -> string -> string -> Type.t -> Type.t -> unit
+
+val add_table_import : Module.t -> string -> string -> string -> unit
+
+val add_memory_import : Module.t -> string -> string -> string -> bool -> unit
+
+val add_global_import :
+  Module.t -> string -> string -> string -> Type.t -> bool -> unit

--- a/virtual/literal.mli
+++ b/virtual/literal.mli
@@ -1,0 +1,13 @@
+type t
+
+val int32 : int32 -> t
+
+val int64 : int64 -> t
+
+val float32_bits : int32 -> t
+
+val float64_bits : int64 -> t
+
+val float32 : float -> t
+
+val float64 : float -> t

--- a/virtual/memory.mli
+++ b/virtual/memory.mli
@@ -1,0 +1,9 @@
+type segment = {
+  name : string;
+  passive : bool;
+  offset : Expression.t;
+  size : int;
+}
+
+val set_memory :
+  Module.t -> int -> int -> string -> segment list -> bool -> unit

--- a/virtual/module.mli
+++ b/virtual/module.mli
@@ -1,0 +1,67 @@
+type t
+
+val create : unit -> t
+
+val dispose : t -> unit
+
+val add_custom_section : t -> string -> string -> unit
+
+val parse : string -> t
+
+val print : t -> unit
+
+val print_asmjs : t -> unit
+
+val validate : t -> int
+
+val optimize : t -> unit
+
+val set_features : t -> int list -> unit
+
+val get_optimize_level : unit -> int
+
+val set_optimize_level : int -> unit
+
+val get_shrink_level : unit -> int
+
+val set_shrink_level : int -> unit
+
+val get_debug_info : unit -> int
+
+val set_debug_info : int -> unit
+
+val get_low_memory_unused : unit -> int
+
+val set_low_memory_unused : int -> unit
+
+val get_pass_argument : string -> string
+
+val set_pass_argument : string -> string -> unit
+
+val get_always_inline_max_size : unit -> int
+
+val set_always_inline_max_size : int -> unit
+
+val get_flexible_inline_max_size : unit -> int
+
+val set_flexible_inline_max_size : int -> unit
+
+val get_one_caller_inline_max_size : unit -> int
+
+val set_one_caller_inline_max_size : int -> unit
+
+val run_passes : t -> string list -> unit
+
+val auto_drop : t -> unit
+
+val write : t -> string option -> bytes * string option
+
+val write_text : t -> string
+
+val read : bytes -> t
+
+val interpret : t -> unit
+
+val add_debug_info_filename : t -> string -> int
+
+val get_debug_info_filename : t -> int -> string

--- a/virtual/op.mli
+++ b/virtual/op.mli
@@ -1,0 +1,685 @@
+type t
+
+val clz_int32 : t
+
+val ctz_int32 : t
+
+val popcnt_int32 : t
+
+val neg_float32 : t
+
+val abs_float32 : t
+
+val ceil_float32 : t
+
+val floor_float32 : t
+
+val trunc_float32 : t
+
+val nearest_float32 : t
+
+val sqrt_float32 : t
+
+val eq_z_int32 : t
+
+val clz_int64 : t
+
+val ctz_int64 : t
+
+val popcnt_int64 : t
+
+val neg_float64 : t
+
+val abs_float64 : t
+
+val ceil_float64 : t
+
+val floor_float64 : t
+
+val trunc_float64 : t
+
+val nearest_float64 : t
+
+val sqrt_float64 : t
+
+val eq_z_int64 : t
+
+val extend_s_int32 : t
+
+val extend_u_int32 : t
+
+val wrap_int64 : t
+
+val trunc_s_float32_to_int32 : t
+
+val trunc_s_float32_to_int64 : t
+
+val trunc_u_float32_to_int32 : t
+
+val trunc_u_float32_to_int64 : t
+
+val trunc_s_float64_to_int32 : t
+
+val trunc_s_float64_to_int64 : t
+
+val trunc_u_float64_to_int32 : t
+
+val trunc_u_float64_to_int64 : t
+
+val reinterpret_float32 : t
+
+val reinterpret_float64 : t
+
+val convert_s_int32_to_float32 : t
+
+val convert_s_int32_to_float64 : t
+
+val convert_u_int32_to_float32 : t
+
+val convert_u_int32_to_float64 : t
+
+val convert_s_int64_to_float32 : t
+
+val convert_s_int64_to_float64 : t
+
+val convert_u_int64_to_float32 : t
+
+val convert_u_int64_to_float64 : t
+
+val promote_float32 : t
+
+val demote_float64 : t
+
+val reinterpret_int32 : t
+
+val reinterpret_int64 : t
+
+val extend_s8_int32 : t
+
+val extend_s16_int32 : t
+
+val extend_s8_int64 : t
+
+val extend_s16_int64 : t
+
+val extend_s32_int64 : t
+
+val add_int32 : t
+
+val sub_int32 : t
+
+val mul_int32 : t
+
+val div_s_int32 : t
+
+val div_u_int32 : t
+
+val rem_s_int32 : t
+
+val rem_u_int32 : t
+
+val and_int32 : t
+
+val or_int32 : t
+
+val xor_int32 : t
+
+val shl_int32 : t
+
+val shr_u_int32 : t
+
+val shr_s_int32 : t
+
+val rot_l_int32 : t
+
+val rot_r_int32 : t
+
+val eq_int32 : t
+
+val ne_int32 : t
+
+val lt_s_int32 : t
+
+val lt_u_int32 : t
+
+val le_s_int32 : t
+
+val le_u_int32 : t
+
+val gt_s_int32 : t
+
+val gt_u_int32 : t
+
+val ge_s_int32 : t
+
+val ge_u_int32 : t
+
+val add_int64 : t
+
+val sub_int64 : t
+
+val mul_int64 : t
+
+val div_s_int64 : t
+
+val div_u_int64 : t
+
+val rem_s_int64 : t
+
+val rem_u_int64 : t
+
+val and_int64 : t
+
+val or_int64 : t
+
+val xor_int64 : t
+
+val shl_int64 : t
+
+val shr_u_int64 : t
+
+val shr_s_int64 : t
+
+val rot_l_int64 : t
+
+val rot_r_int64 : t
+
+val eq_int64 : t
+
+val ne_int64 : t
+
+val lt_s_int64 : t
+
+val lt_u_int64 : t
+
+val le_s_int64 : t
+
+val le_u_int64 : t
+
+val gt_s_int64 : t
+
+val gt_u_int64 : t
+
+val ge_s_int64 : t
+
+val ge_u_int64 : t
+
+val add_float32 : t
+
+val sub_float32 : t
+
+val mul_float32 : t
+
+val div_float32 : t
+
+val copy_sign_float32 : t
+
+val min_float32 : t
+
+val max_float32 : t
+
+val eq_float32 : t
+
+val ne_float32 : t
+
+val lt_float32 : t
+
+val le_float32 : t
+
+val gt_float32 : t
+
+val ge_float32 : t
+
+val add_float64 : t
+
+val sub_float64 : t
+
+val mul_float64 : t
+
+val div_float64 : t
+
+val copy_sign_float64 : t
+
+val min_float64 : t
+
+val max_float64 : t
+
+val eq_float64 : t
+
+val ne_float64 : t
+
+val lt_float64 : t
+
+val le_float64 : t
+
+val gt_float64 : t
+
+val ge_float64 : t
+
+val memory_size : t
+
+val memory_grow : t
+
+val atomic_rmw_add : t
+
+val atomic_rmw_sub : t
+
+val atomic_rmw_and : t
+
+val atomic_rmw_or : t
+
+val atomic_rmw_xor : t
+
+val atomic_rmw_xchg : t
+
+val trunc_sat_s_float32_to_int32 : t
+
+val trunc_sat_s_float32_to_int64 : t
+
+val trunc_sat_u_float32_to_int32 : t
+
+val trunc_sat_u_float32_to_int64 : t
+
+val trunc_sat_s_float64_to_int32 : t
+
+val trunc_sat_s_float64_to_int64 : t
+
+val trunc_sat_u_float64_to_int32 : t
+
+val trunc_sat_u_float64_to_int64 : t
+
+val splat_vec_i8x16 : t
+
+val extract_lane_s_vec_i8x16 : t
+
+val extract_lane_u_vec_i8x16 : t
+
+val replace_lane_vec_i8x16 : t
+
+val splat_vec_i16x8 : t
+
+val extract_lane_s_vec_i16x8 : t
+
+val extract_lane_u_vec_i16x8 : t
+
+val replace_lane_vec_i16x8 : t
+
+val splat_vec_i32x4 : t
+
+val extract_lane_vec_i32x4 : t
+
+val replace_lane_vec_i32x4 : t
+
+val splat_vec_i64x2 : t
+
+val extract_lane_vec_i64x2 : t
+
+val replace_lane_vec_i64x2 : t
+
+val splat_vec_f32x4 : t
+
+val extract_lane_vec_f32x4 : t
+
+val replace_lane_vec_f32x4 : t
+
+val splat_vec_f64x2 : t
+
+val extract_lane_vec_f64x2 : t
+
+val replace_lane_vec_f64x2 : t
+
+val eq_vec_i8x16 : t
+
+val ne_vec_i8x16 : t
+
+val lt_s_vec_i8x16 : t
+
+val lt_u_vec_i8x16 : t
+
+val gt_s_vec_i8x16 : t
+
+val gt_u_vec_i8x16 : t
+
+val le_s_vec_i8x16 : t
+
+val le_u_vec_i8x16 : t
+
+val ge_s_vec_i8x16 : t
+
+val ge_u_vec_i8x16 : t
+
+val eq_vec_i16x8 : t
+
+val ne_vec_i16x8 : t
+
+val lt_s_vec_i16x8 : t
+
+val lt_u_vec_i16x8 : t
+
+val gt_s_vec_i16x8 : t
+
+val gt_u_vec_i16x8 : t
+
+val le_s_vec_i16x8 : t
+
+val le_u_vec_i16x8 : t
+
+val ge_s_vec_i16x8 : t
+
+val ge_u_vec_i16x8 : t
+
+val eq_vec_i32x4 : t
+
+val ne_vec_i32x4 : t
+
+val lt_s_vec_i32x4 : t
+
+val lt_u_vec_i32x4 : t
+
+val gt_s_vec_i32x4 : t
+
+val gt_u_vec_i32x4 : t
+
+val le_s_vec_i32x4 : t
+
+val le_u_vec_i32x4 : t
+
+val ge_s_vec_i32x4 : t
+
+val ge_u_vec_i32x4 : t
+
+val eq_vec_f32x4 : t
+
+val ne_vec_f32x4 : t
+
+val lt_vec_f32x4 : t
+
+val gt_vec_f32x4 : t
+
+val le_vec_f32x4 : t
+
+val ge_vec_f32x4 : t
+
+val eq_vec_f64x2 : t
+
+val ne_vec_f64x2 : t
+
+val lt_vec_f64x2 : t
+
+val gt_vec_f64x2 : t
+
+val le_vec_f64x2 : t
+
+val ge_vec_f64x2 : t
+
+val not_vec128 : t
+
+val and_vec128 : t
+
+val or_vec128 : t
+
+val xor_vec128 : t
+
+val and_not_vec128 : t
+
+val bitselect_vec128 : t
+
+val abs_vec_i8x16 : t
+
+val neg_vec_i8x16 : t
+
+val any_true_vec_i8x16 : t
+
+val all_true_vec_i8x16 : t
+
+val bitmask_vec_i8x16 : t
+
+val shl_vec_i8x16 : t
+
+val shr_s_vec_i8x16 : t
+
+val shr_u_vec_i8x16 : t
+
+val add_vec_i8x16 : t
+
+val add_sat_s_vec_i8x16 : t
+
+val add_sat_u_vec_i8x16 : t
+
+val sub_vec_i8x16 : t
+
+val sub_sat_s_vec_i8x16 : t
+
+val sub_sat_u_vec_i8x16 : t
+
+val mul_vec_i8x16 : t
+
+val min_s_vec_i8x16 : t
+
+val min_u_vec_i8x16 : t
+
+val max_s_vec_i8x16 : t
+
+val max_u_vec_i8x16 : t
+
+val avgr_u_vec_i8x16 : t
+
+val abs_vec_i16x8 : t
+
+val neg_vec_i16x8 : t
+
+val any_true_vec_i16x8 : t
+
+val all_true_vec_i16x8 : t
+
+val bitmask_vec_i16x8 : t
+
+val shl_vec_i16x8 : t
+
+val shr_s_vec_i16x8 : t
+
+val shr_u_vec_i16x8 : t
+
+val add_vec_i16x8 : t
+
+val add_sat_s_vec_i16x8 : t
+
+val add_sat_u_vec_i16x8 : t
+
+val sub_vec_i16x8 : t
+
+val sub_sat_s_vec_i16x8 : t
+
+val sub_sat_u_vec_i16x8 : t
+
+val mul_vec_i16x8 : t
+
+val min_s_vec_i16x8 : t
+
+val min_u_vec_i16x8 : t
+
+val max_s_vec_i16x8 : t
+
+val max_u_vec_i16x8 : t
+
+val avgr_u_vec_i16x8 : t
+
+val abs_vec_i32x4 : t
+
+val neg_vec_i32x4 : t
+
+val any_true_vec_i32x4 : t
+
+val all_true_vec_i32x4 : t
+
+val bitmask_vec_i32x4 : t
+
+val shl_vec_i32x4 : t
+
+val shr_s_vec_i32x4 : t
+
+val shr_u_vec_i32x4 : t
+
+val add_vec_i32x4 : t
+
+val sub_vec_i32x4 : t
+
+val mul_vec_i32x4 : t
+
+val min_s_vec_i32x4 : t
+
+val min_u_vec_i32x4 : t
+
+val max_s_vec_i32x4 : t
+
+val max_u_vec_i32x4 : t
+
+val dot_s_vec_i16x8_to_vec_i32x4 : t
+
+val neg_vec_i64x2 : t
+
+val any_true_vec_i64x2 : t
+
+val all_true_vec_i64x2 : t
+
+val shl_vec_i64x2 : t
+
+val shr_s_vec_i64x2 : t
+
+val shr_u_vec_i64x2 : t
+
+val add_vec_i64x2 : t
+
+val sub_vec_i64x2 : t
+
+val mul_vec_i64x2 : t
+
+val abs_vec_f32x4 : t
+
+val neg_vec_f32x4 : t
+
+val sqrt_vec_f32x4 : t
+
+val qfma_vec_f32x4 : t
+
+val qfms_vec_f32x4 : t
+
+val add_vec_f32x4 : t
+
+val sub_vec_f32x4 : t
+
+val mul_vec_f32x4 : t
+
+val div_vec_f32x4 : t
+
+val min_vec_f32x4 : t
+
+val max_vec_f32x4 : t
+
+val p_min_vec_f32x4 : t
+
+val p_max_vec_f32x4 : t
+
+val ceil_vec_f32x4 : t
+
+val floor_vec_f32x4 : t
+
+val trunc_vec_f32x4 : t
+
+val nearest_vec_f32x4 : t
+
+val abs_vec_f64x2 : t
+
+val neg_vec_f64x2 : t
+
+val sqrt_vec_f64x2 : t
+
+val qfma_vec_f64x2 : t
+
+val qfms_vec_f64x2 : t
+
+val add_vec_f64x2 : t
+
+val sub_vec_f64x2 : t
+
+val mul_vec_f64x2 : t
+
+val div_vec_f64x2 : t
+
+val min_vec_f64x2 : t
+
+val max_vec_f64x2 : t
+
+val p_min_vec_f64x2 : t
+
+val p_max_vec_f64x2 : t
+
+val ceil_vec_f64x2 : t
+
+val floor_vec_f64x2 : t
+
+val trunc_vec_f64x2 : t
+
+val nearest_vec_f64x2 : t
+
+val trunc_sat_s_vec_f32x4_to_vec_i32x4 : t
+
+val trunc_sat_u_vec_f32x4_to_vec_i32x4 : t
+
+val trunc_sat_s_vec_f64x2_to_vec_i64x2 : t
+
+val trunc_sat_u_vec_f64x2_to_vec_i64x2 : t
+
+val convert_s_vec_i32x4_to_vec_f32x4 : t
+
+val convert_u_vec_i32x4_to_vec_f32x4 : t
+
+val convert_s_vec_i64x2_to_vec_f64x2 : t
+
+val convert_u_vec_i64x2_to_vec_f64x2 : t
+
+val load_splat_vec8x16 : t
+
+val load_splat_vec16x8 : t
+
+val load_splat_vec32x4 : t
+
+val load_splat_vec64x2 : t
+
+val load_ext_s_vec8x8_to_vec_i16x8 : t
+
+val load_ext_u_vec8x8_to_vec_i16x8 : t
+
+val load_ext_s_vec16x4_to_vec_i32x4 : t
+
+val load_ext_u_vec16x4_to_vec_i32x4 : t
+
+val load_ext_s_vec32x2_to_vec_i64x2 : t
+
+val load_ext_u_vec32x2_to_vec_i64x2 : t
+
+val narrow_s_vec_i16x8_to_vec_i8x16 : t
+
+val narrow_u_vec_i16x8_to_vec_i8x16 : t
+
+val narrow_s_vec_i32x4_to_vec_i16x8 : t
+
+val narrow_u_vec_i32x4_to_vec_i16x8 : t
+
+val widen_low_s_vec_i8x16_to_vec_i16x8 : t
+
+val widen_high_s_vec_i8x16_to_vec_i16x8 : t
+
+val widen_low_u_vec_i8x16_to_vec_i16x8 : t
+
+val widen_high_u_vec_i8x16_to_vec_i16x8 : t
+
+val widen_low_s_vec_i16x8_to_vec_i32x4 : t
+
+val widen_high_s_vec_i16x8_to_vec_i32x4 : t
+
+val widen_low_u_vec_i16x8_to_vec_i32x4 : t
+
+val widen_high_u_vec_i16x8_to_vec_i32x4 : t
+
+val swizzle_vec8x16 : t

--- a/virtual/type.mli
+++ b/virtual/type.mli
@@ -1,0 +1,27 @@
+type t
+
+val none : t
+
+val int32 : t
+
+val int64 : t
+
+val float32 : t
+
+val float64 : t
+
+val vec128 : t
+
+val funcref : t
+
+val externref : t
+
+val nullref : t
+
+val exnref : t
+
+val unreachable : t
+
+val auto : t
+
+val create : t array -> t


### PR DESCRIPTION
This adds a virtual interface to the Binaryen.ml package and renames the native implementation as `binaryen.native`. This is set as the default implementation so people can depend on `binaryen` without pulling in native explicitly, but sets us up to add JS support in my next PR.