### PR TITLE
Fix typo in esy workflow

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Then build in non-release so we can test
       - name: Build dependencies
-        if: steps.deps-cache.outputs.cache-hit != 'true'
+        if: steps.esy-cache.outputs.cache-hit != 'true'
         run: |
           esy build-dependencies
 


### PR DESCRIPTION
Found a typo that that continued to build deps even when pulled from cache.