### PR TITLE
Bump version for failed npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grain/binaryen.ml",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OCaml bindings for Binaryen.",
   "author": "Oscar Spencer <oscar@grain-lang.org>",
   "license": "Apache-2.0",


### PR DESCRIPTION
I had a bug in my publish to npm, so I needed to fix it and bump the patch version.

I'm not trying to solve the problem of aligning versions right now and we'll be cutting a binaryen.ml 0.4 with the upstream changes once they version binaryen 99 and we will push that out to everywhere.