### PR TITLE
ci: use maintained action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           brew install git-archive-all
 
-      - uses: olegtarasov/get-tag@v2
+      - uses: little-core-labs/get-git-tag@v3.0.2
         id: tag_name
 
       - name: Checkout code


### PR DESCRIPTION
The Actions security changes broke our release workflow. I think this will fix it.