### PR TITLE
chore: Add --no-browser flag to opam-publish

### DIFF
--- a/.github/workflows/opam-publish.yml
+++ b/.github/workflows/opam-publish.yml
@@ -39,11 +39,6 @@ jobs:
           mkdir -p  ~/.opam/plugins/opam-publish/
           echo -n ${{ secrets.OPAM_RELEASE }} > ~/.opam/plugins/opam-publish/binaryen.token
 
-      # This is the only way to make opam publish "headless" currently
-      - name: Remove xdg-open
-        run: |
-          sudo rm $(which xdg-open)
-
       - name: Generate CHANGES file
         run: |
           echo -n "${{ github.event.release.body }}" > CHANGES.md
@@ -59,4 +54,4 @@ jobs:
 
       - name: Publish to opam
         run: |
-          opam publish --msg-file=CHANGES.md ${{ github.event.release.assets[0].browser_download_url }}
+          opam publish --no-browser --msg-file=CHANGES.md ${{ github.event.release.assets[0].browser_download_url }}


### PR DESCRIPTION
My [opam-publish patch](https://github.com/ocaml-opam/opam-publish/pull/110) landed awhile ago. This removes 1 hack in our workflow for automated publishes.