### PR TITLE
ci: run opam build on ubuntu 18 instead of 20

### DIFF
--- a/.github/workflows/opam-publish.yml
+++ b/.github/workflows/opam-publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         ocaml-version: [4.10.0]
 
     steps:

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
         ocaml-version: [4.11.1]
 
     steps:


### PR DESCRIPTION
For some reason the opam builds won't succeed on GitHub's Ubuntu 20.04 due to some `undefined symbol: pthreads_create` error.

I can't figure out why this is the case, so let's just revert to Ubuntu 18.04 for opam flows.