### PR TITLE
ci: fix markdown escaping for opam release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Generate CHANGES file
         run: |
-          echo -n "${{ needs.release-please.outputs.body }}" > CHANGES.md
+          printf "%q" '${{ needs.release-please.outputs.body }}' > CHANGES.md
 
       - name: Setup OCaml
         uses: avsm/setup-ocaml@v1


### PR DESCRIPTION
I don't actually know if this will work.