### PR TITLE
fix(js): return JS null value from Expression.null

### DIFF
--- a/js/expression.ml
+++ b/js/expression.ml
@@ -179,8 +179,7 @@ let tuple_extract wasm_mod tuple index =
 let pop wasm_mod typ =
   meth_call global##.binaryen "_BinaryenPop" [| inject wasm_mod; inject typ |]
 
-(* TODO: Figure this out *)
-let null () = Obj.magic ()
+let null () = pure_js_expr "null"
 
 let print expr =
   let text = meth_call global##.binaryen "emitText" [| inject expr |] in

--- a/test/test.expected
+++ b/test/test.expected
@@ -5,6 +5,10 @@
  (export "memory" (memory $0))
  (func $adder (param $0 i32) (param $1 i32) (result i32)
   (block $add (result i32)
+   (if
+    (i32.const 0)
+    (unreachable)
+   )
    (i32.add
     (select
      (local.get $0)

--- a/test/test.ml
+++ b/test/test.ml
@@ -20,7 +20,10 @@ let select =
 
 let bin = Expression.binary wasm_mod Op.add_int32 select (y ())
 
-let add = Expression.block wasm_mod ~return_type:Type.int32 "add" [ bin ]
+let add = Expression.block wasm_mod ~return_type:Type.int32 "add" [
+  Expression.if_ wasm_mod (Expression.const wasm_mod (Literal.int32 0l)) (Expression.unreachable wasm_mod) (Expression.null ());
+  bin 
+]
 
 (* Create the add function *)
 let adder = Function.add_function wasm_mod "adder" params results [||] add


### PR DESCRIPTION
Binaryen.js uses a JavaScript `null` for the null expression, so we just use a pure JS value for this.

I want to add a test for this, but I need @ospencer's help.