### PR TITLE
fix(js): cast the call_indirect string arguments to JS strings

### DIFF
--- a/js/expression.ml
+++ b/js/expression.ml
@@ -40,7 +40,7 @@ let call wasm_mod name params return_typ =
 let call_indirect wasm_mod table target params params_typ return_typ =
   meth_call wasm_mod "call_indirect"
     [|
-      inject table;
+      inject (string table);
       inject target;
       inject (array (Array.of_list params));
       inject params_typ;
@@ -58,7 +58,7 @@ let return_call wasm_mod name params return_typ =
 let return_call_indirect wasm_mod table target params params_typ return_typ =
   meth_call wasm_mod "return_call_indirect"
     [|
-      inject table;
+      inject (string table);
       inject target;
       inject (array (Array.of_list params));
       inject params_typ;

--- a/js/table.ml
+++ b/js/table.ml
@@ -1,0 +1,12 @@
+open Js_of_ocaml.Js
+open Js_of_ocaml.Js.Unsafe
+
+let add_table wasm_mod name initial maximum funcnames offset =
+  meth_call wasm_mod "addTable"
+    [|
+      inject (string name);
+      inject initial;
+      inject maximum;
+      inject (array (Array.of_list (List.map string funcnames)));
+      inject offset;
+    |]

--- a/src/binaryen_stubs_tables.c
+++ b/src/binaryen_stubs_tables.c
@@ -1,0 +1,31 @@
+#define CAML_NAME_SPACE
+#include <caml/mlvalues.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+
+#include "binaryen-c.h"
+#include "ocaml_helpers.h"
+
+
+CAMLprim value
+caml_binaryen_add_table(value _module, value _name, value _initial, value _maximum, value _funcnames, value _offset) {
+  CAMLparam5(_module, _name, _initial, _maximum, _funcnames);
+  CAMLxparam1(_offset);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  char* name = Safe_String_val(_name);
+  BinaryenIndex initial = Int_val(_initial);
+  BinaryenIndex maximum = Int_val(_maximum);
+  _funcnames = array_of_list(_funcnames);
+  int funcnamesLen = array_length(_funcnames);
+  const char* funcnames[funcnamesLen];
+  for (int i = 0; i < funcnamesLen; i++) {
+    funcnames[i] = Safe_String_val(Field(_funcnames, i));
+  }
+  BinaryenExpressionRef offset = BinaryenExpressionRef_val(_offset);
+  BinaryenAddTable(module, name, initial, maximum, funcnames, funcnamesLen, offset);
+  CAMLreturn(Val_unit);
+}
+CAMLprim value
+caml_binaryen_add_table__bytecode(value * argv) {
+  return caml_binaryen_add_table(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
+}

--- a/src/dune
+++ b/src/dune
@@ -7,8 +7,9 @@
   (names binaryen_stubs_types binaryen_stubs_ops binaryen_stubs_literals
     binaryen_stubs_expressions binaryen_stubs_functions
     binaryen_stubs_imports binaryen_stubs_exports binaryen_stubs_globals
-    binaryen_stubs_function_tables binaryen_stubs_memory
-    binaryen_stubs_features binaryen_stubs_modules ocaml_helpers)
+    binaryen_stubs_function_tables binaryen_stubs_tables
+    binaryen_stubs_memory binaryen_stubs_features binaryen_stubs_modules
+    ocaml_helpers)
   (flags -O2 -Wall -Wextra))
  (foreign_archives binaryen)
  (library_flags

--- a/src/table.ml
+++ b/src/table.ml
@@ -1,0 +1,4 @@
+external add_table :
+  Module.t -> string -> int -> int -> string list -> Expression.t -> unit
+  = "caml_binaryen_add_table__bytecode" "caml_binaryen_add_table"
+(** Module, name, initial size, maximum size, function names, offset. *)

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,6 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (memory $0 1)
+ (table $table 1 1 funcref)
+ (elem (i32.const 0) $adder)
  (export "adder" (func $adder))
  (export "memory" (memory $0))
  (func $adder (param $0 i32) (param $1 i32) (result i32)

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,10 +1,12 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_none (func))
  (memory $0 1)
  (table $table 1 1 funcref)
  (elem (i32.const 0) $adder)
  (export "adder" (func $adder))
  (export "memory" (memory $0))
+ (start $start)
  (func $adder (param $0 i32) (param $1 i32) (result i32)
   (block $add (result i32)
    (if
@@ -23,12 +25,25 @@
    )
   )
  )
+ (func $start
+  (drop
+   (call_indirect (type $i32_i32_=>_i32)
+    (i32.const 3)
+    (i32.const 5)
+    (i32.const 0)
+   )
+  )
+ )
 )
 (module
+ (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (memory $0 1)
+ (table $table 1 1 funcref)
+ (elem (i32.const 0) $adder)
  (export "adder" (func $adder))
  (export "memory" (memory $0))
+ (start $start)
  (func $adder (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (select
@@ -41,12 +56,24 @@
    (local.get $1)
   )
  )
+ (func $start (; has Stack IR ;)
+  (drop
+   (call $adder
+    (i32.const 3)
+    (i32.const 5)
+   )
+  )
+ )
 )
 (module
+ (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (memory $0 1)
+ (table $0 1 1 funcref)
+ (elem (i32.const 0) $0)
  (export "adder" (func $0))
  (export "memory" (memory $0))
+ (start $1)
  (func $0 (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (select
@@ -57,6 +84,14 @@
     (i32.const 1)
    )
    (local.get $1)
+  )
+ )
+ (func $1
+  (drop
+   (call $0
+    (i32.const 3)
+    (i32.const 5)
+   )
   )
  )
 )

--- a/test/test.ml
+++ b/test/test.ml
@@ -30,6 +30,10 @@ let adder = Function.add_function wasm_mod "adder" params results [||] add
 
 let _ = Export.add_function_export wasm_mod "adder" "adder"
 
+let _ =
+  Table.add_table wasm_mod "table" 1 1 [ "adder" ]
+    (Expression.const wasm_mod (Literal.int32 0l))
+
 let _ = Memory.set_memory wasm_mod 1 Memory.unlimited "memory" [] false
 
 let _ = Module.print wasm_mod

--- a/virtual/dune
+++ b/virtual/dune
@@ -1,6 +1,6 @@
 (library
  (name binaryen)
  (public_name binaryen)
- (virtual_modules export expression features function function_table global
-   import literal memory module op type)
+ (virtual_modules export expression features function function_table table
+   global import literal memory module op type)
  (default_implementation binaryen.native))

--- a/virtual/table.mli
+++ b/virtual/table.mli
@@ -1,0 +1,2 @@
+val add_table :
+  Module.t -> string -> int -> int -> string list -> Expression.t -> unit


### PR DESCRIPTION
This fixes the JS version of `call_indirect` methods by properly converting the table name OCaml string to a JS string.

I want to add a test for this but I need @ospencer's help.