### PR TITLE
fix(js): utilize JSOO externals to convert between uint8array & bytes

### DIFF
--- a/js/dune
+++ b/js/dune
@@ -5,6 +5,9 @@
  (libraries js_of_ocaml)
  (preprocess
   (pps js_of_ocaml-ppx))
+ (foreign_stubs
+  (language c)
+  (names stubs))
  (js_of_ocaml
   (flags --no-sourcemap)
   (javascript_files binaryen.js postlude.js)))

--- a/js/stubs.c
+++ b/js/stubs.c
@@ -1,0 +1,15 @@
+// Ref https://github.com/ocsigen/js_of_ocaml/issues/804#issuecomment-495826520
+#include <stdlib.h>
+#include <stdio.h>
+void caml_bytes_of_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_bytes_of_array!\n");
+  exit(1);
+}
+void caml_array_of_bytes () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_array_of_bytes!\n");
+  exit(1);
+}
+void caml_array_of_string () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_array_of_string!\n");
+  exit(1);
+}


### PR DESCRIPTION
This switches the hand-rolled encoding stuff to just defer to the JSOO externals. We don't use the `read` method in Grain, so that isn't tested (so I left the comment that we need to check it), but I believe the other 2 are exercised in the Grain codebase.