### PR TITLE
feat: add Function_table.unlimited constant

### DIFF
--- a/js/function_table.ml
+++ b/js/function_table.ml
@@ -9,3 +9,5 @@ let set_function_table wasm_mod initial maximum funcnames offset =
       inject (array (Array.of_list (List.map string funcnames)));
       inject offset;
     |]
+
+let unlimited = -1

--- a/src/function_table.ml
+++ b/src/function_table.ml
@@ -2,3 +2,5 @@ external set_function_table :
   Module.t -> int -> int -> string list -> Expression.t -> unit
   = "caml_binaryen_set_function_table"
 (** Module, initial size, maximum size, function names, offset. *)
+
+let unlimited = -1

--- a/virtual/function_table.mli
+++ b/virtual/function_table.mli
@@ -1,2 +1,4 @@
 val set_function_table :
   Module.t -> int -> int -> string list -> Expression.t -> unit
+
+val unlimited : int


### PR DESCRIPTION
This adds an `unlimited` constant value to `Function_table` because the value you need to use for "unlimited" is `-1`. This is now the same as `Memory.unlimited`