### PR TITLE
chore: Replace git:// protocol in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Build archive
         run: |
@@ -68,7 +68,7 @@ jobs:
       - name: Setup opam repository
         run: |
           mkdir -p  ~/.opam/plugins/opam-publish/repos/
-          git clone git://github.com/ocaml/opam-repository ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
+          git clone https://github.com/ocaml/opam-repository ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
           cd ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
           git remote add user https://${{ secrets.OPAM_RELEASE }}@github.com/grainbot/opam-repository
 


### PR DESCRIPTION
Github disabled this protocol and broke the workflow.

Closes #114 