### PR TITLE
chore: Add publishConfig for our package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "installConfig": {
     "pnp": false
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "binaryen",
     "ocaml"


### PR DESCRIPTION
This just adds a publishConfig to the package.json (in case we copy-paste this project into another).

Closes #115 