### PR TITLE
chore: Allow ocaml 4.13 in opam

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         ocaml-compiler: [4.12.0, 4.13.0]
 
     steps:

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ocaml-compiler: [4.12.0]
+        ocaml-compiler: [4.12.0, 4.13.0]
 
     steps:
       - name: Checkout project

--- a/binaryen.opam
+++ b/binaryen.opam
@@ -12,7 +12,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.12" < "4.13"}
+  "ocaml" {>= "4.12"}
   "dune" {>= "2.9.1"}
   "dune-configurator" {>= "2.9.1"}
   "js_of_ocaml" {>= "3.10.0"}


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/20447, the opam team removed our upper bounds on ocaml version. This aligns it.