### PR TITLE
fix: Make features work in 32-bit mode

### DIFF
--- a/js/module.ml
+++ b/js/module.ml
@@ -74,7 +74,9 @@ let get_features wasm_mod =
         feature :: split_features (feature lsr 1)
     | feature -> split_features (feature lsr 1)
   in
-  split_features 0x80000000
+  (* Support 32-bit OCaml where integers are 31 bits *)
+  (* This supports up to 31 Binaryen features *)
+  split_features 0x40000000
 
 let set_features wasm_mod features =
   meth_call wasm_mod "setFeatures"

--- a/src/module.ml
+++ b/src/module.ml
@@ -85,7 +85,9 @@ let get_features wasm_mod =
         feature :: split_features (feature lsr 1)
     | feature -> split_features (feature lsr 1)
   in
-  split_features 0x80000000
+  (* Support 32-bit OCaml where integers are 31 bits *)
+  (* This supports up to 31 Binaryen features *)
+  split_features 0x40000000
 
 external set_features : t -> int -> unit = "caml_binaryen_module_set_features"
 


### PR DESCRIPTION
There are currently 14 Binaryen features, so this shouldn't break unless that number expands to 32, which is fairly unlikely.