### PR TITLE
fix: Handle JS global in non-node environments

### DIFF
--- a/js/dune
+++ b/js/dune
@@ -10,4 +10,4 @@
   (names stubs))
  (js_of_ocaml
   (flags --no-sourcemap)
-  (javascript_files binaryen.es5.js postlude.js)))
+  (javascript_files prelude.js binaryen.es5.js postlude.js)))

--- a/js/postlude.js
+++ b/js/postlude.js
@@ -1,2 +1,2 @@
-// Attach binaryen to our global
-global.binaryen = module.exports;
+// Attach binaryen to globalThis because JSOO wraps in an iife
+globalThis.binaryen = module.exports;

--- a/js/prelude.js
+++ b/js/prelude.js
@@ -1,0 +1,11 @@
+if (typeof module === 'undefined') {
+  module = {};
+}
+
+if (typeof exports === 'undefined') {
+  exports = {};
+}
+
+if (typeof module.exports === 'undefined') {
+  module.exports = exports;
+}


### PR DESCRIPTION
I'm trying some tweaks for our JSOO build in non-nodejs environments.