### PR TITLE
feat: Upgrade to libbinaryen v103

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -18,5 +18,5 @@ depends: [
   "js_of_ocaml" {>= "3.10.0" < "4.0.0"}
   "js_of_ocaml-ppx" {>= "3.10.0" < "4.0.0"}
   "js_of_ocaml-compiler" {>= "3.10.0" < "4.0.0"}
-  "libbinaryen" {>= "102.0.4" < "103.0.0"}
+  "libbinaryen" {>= "103.0.1" < "104.0.0"}
 ]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ffd6d932e46e6aa0a49050693b592036",
+  "checksum": "13f3f4c2715b999554a5ca3aace8c44b",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@4.13.1000@d41d8cd9": {
@@ -1317,14 +1317,14 @@
       ],
       "devDependencies": [ "ocaml@4.13.1000@d41d8cd9" ]
     },
-    "@grain/libbinaryen@102.0.4@d41d8cd9": {
-      "id": "@grain/libbinaryen@102.0.4@d41d8cd9",
+    "@grain/libbinaryen@103.0.1@d41d8cd9": {
+      "id": "@grain/libbinaryen@103.0.1@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "102.0.4",
+      "version": "103.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-102.0.4.tgz#sha1:13afb8a3220d17b02b3069713f07d87356ffbe11"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-103.0.1.tgz#sha1:5e5c400a5b539ea6bdbe6429863c90abd0530d91"
         ]
       },
       "overrides": [],
@@ -1353,7 +1353,7 @@
         "@opam/js_of_ocaml@opam:3.11.0@93e18d4d",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
         "@opam/dune@opam:2.9.3@f57a6d69",
-        "@grain/libbinaryen@102.0.4@d41d8cd9"
+        "@grain/libbinaryen@103.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.20.1@6e37e311",

--- a/js/dune
+++ b/js/dune
@@ -10,4 +10,4 @@
   (names stubs))
  (js_of_ocaml
   (flags --no-sourcemap)
-  (javascript_files prelude.js binaryen.es5.js postlude.js)))
+  (javascript_files prelude.js binaryen.es5.js)))

--- a/js/export.ml
+++ b/js/export.ml
@@ -46,11 +46,8 @@ let external_function =
   meth_call global##.binaryen "_BinaryenExternalFunction" [||]
 
 let external_table = meth_call global##.binaryen "_BinaryenExternalTable" [||]
-
 let external_memory = meth_call global##.binaryen "_BinaryenExternalMemory" [||]
-
 let external_global = meth_call global##.binaryen "_BinaryenExternalGlobal" [||]
-
 let external_tag = meth_call global##.binaryen "_BinaryenExternalTag" [||]
 
 let export_get_kind export =

--- a/js/expression.ml
+++ b/js/expression.ml
@@ -942,3 +942,164 @@ end
 module Null = struct
   let make () = pure_js_expr "null"
 end
+
+module Ref = struct
+  (** Module, type *)
+  let null wasm_mod typ =
+    let scope = get wasm_mod "ref" in
+    meth_call scope "null" [| inject typ |]
+
+  (** Module, op, value *)
+  let is wasm_mod op value =
+    meth_call global##.binaryen "_BinaryenRefIs"
+      [| inject wasm_mod; inject op; inject value |]
+
+  (** Module, op, value *)
+  let as_ wasm_mod op value =
+    meth_call global##.binaryen "_BinaryenRefAs"
+      [| inject wasm_mod; inject op; inject value |]
+
+  (** Module, func, type *)
+  let func wasm_mod func typ =
+    let scope = get wasm_mod "ref" in
+    meth_call scope "func" [| inject (string func); inject typ |]
+
+  (** Module, left, right *)
+  let eq wasm_mod left right =
+    let scope = get wasm_mod "ref" in
+    meth_call scope "func" [| inject left; inject right |]
+end
+
+module Table = struct
+  (** Module, name, index, type *)
+  let get wasm_mod name index typ =
+    let scope = Js_of_ocaml.Js.Unsafe.get wasm_mod "table" in
+    meth_call scope "get" [| inject (string name); inject index; inject typ |]
+
+  (** Module, name, index, value *)
+  let set wasm_mod name index value =
+    let scope = Js_of_ocaml.Js.Unsafe.get wasm_mod "table" in
+    meth_call scope "set" [| inject (string name); inject index; inject value |]
+
+  (** Module, name *)
+  let size wasm_mod name =
+    let scope = Js_of_ocaml.Js.Unsafe.get wasm_mod "table" in
+    meth_call scope "size" [| inject (string name) |]
+
+  (** Module, name, value, delta *)
+  let grow wasm_mod name value delta =
+    let scope = Js_of_ocaml.Js.Unsafe.get wasm_mod "table" in
+    meth_call scope "grow"
+      [| inject (string name); inject value; inject delta |]
+end
+
+module Table_get = struct
+  (** Gets the name of the table being accessed by a `Table.get` expression. *)
+  let get_table exp =
+    to_string
+      (meth_call global ##. binaryen ##. TableGet "getTable" [| inject exp |])
+
+  (** Gets the name of the table being accessed by a `Table.get` expression. *)
+  let set_table exp name =
+    meth_call
+      global ##. binaryen ##. TableGet
+      "setTable"
+      [| inject exp; inject (string name) |]
+
+  (** Gets the index expression of a `Table.get` expression. *)
+  let get_index exp =
+    meth_call global ##. binaryen ##. TableGet "getIndex" [| inject exp |]
+
+  (** Gets the index expression of a `Table.get` expression. *)
+  let set_index exp index =
+    meth_call
+      global ##. binaryen ##. TableGet
+      "setIndex"
+      [| inject exp; inject index |]
+end
+
+module Table_set = struct
+  (** Gets the name of the table being accessed by a `Table.set` expression. *)
+  let get_table exp =
+    to_string
+      (meth_call global ##. binaryen ##. TableSet "getTable" [| inject exp |])
+
+  (** Sets the name of the table being accessed by a `Table.set` expression. *)
+  let set_table exp name =
+    meth_call
+      global ##. binaryen ##. TableSet
+      "setTable"
+      [| inject exp; inject (string name) |]
+
+  (** Gets the index expression of a `Table.set` expression. *)
+  let get_index exp =
+    meth_call global ##. binaryen ##. TableSet "getIndex" [| inject exp |]
+
+  (** Sets the index expression of a `Table.set` expression. *)
+  let set_index exp index =
+    meth_call
+      global ##. binaryen ##. TableSet
+      "setIndex"
+      [| inject exp; inject index |]
+
+  (** Gets the value expression of a `Table.set` expression. *)
+  let get_value exp =
+    meth_call global ##. binaryen ##. TableSet "getValue" [| inject exp |]
+
+  (** Sets the value expression of a `Table.set` expression. *)
+  let set_value exp value =
+    meth_call
+      global ##. binaryen ##. TableSet
+      "setValue"
+      [| inject exp; inject value |]
+end
+
+module Table_size = struct
+  (** Gets the name of the table being accessed by a `Table.size` expression. *)
+  let get_table exp =
+    to_string
+      (meth_call global ##. binaryen ##. TableSize "getTable" [| inject exp |])
+
+  (** Sets the name of the table being accessed by a `Table.size` expression. *)
+  let set_table exp name =
+    meth_call
+      global ##. binaryen ##. TableSize
+      "setTable"
+      [| inject exp; inject (string name) |]
+end
+
+module Table_grow = struct
+  (** Gets the name of the table being accessed by a `Table.grow` expression. *)
+  let get_table exp =
+    to_string
+      (meth_call global ##. binaryen ##. TableGrow "getTable" [| inject exp |])
+
+  (** Gets the name of the table being accessed by a `Table.grow` expression. *)
+  let set_table exp name =
+    meth_call
+      global ##. binaryen ##. TableGrow
+      "setTable"
+      [| inject exp; inject (string name) |]
+
+  (** Gets the value expression of a `Table.grow` expression. *)
+  let get_value exp =
+    meth_call global ##. binaryen ##. TableGrow "getValue" [| inject exp |]
+
+  (** Sets the value expression of a `Table.grow` expression. *)
+  let set_value exp value =
+    meth_call
+      global ##. binaryen ##. TableGrow
+      "setValue"
+      [| inject exp; inject value |]
+
+  (** Gets the delta of a `Table.grow` expression. *)
+  let get_delta exp =
+    meth_call global ##. binaryen ##. TableGrow "getDelta" [| inject exp |]
+
+  (** Sets the delta of a `Table.grow` expression. *)
+  let set_delta exp delta =
+    meth_call
+      global ##. binaryen ##. TableGrow
+      "setDelta"
+      [| inject exp; inject delta |]
+end

--- a/js/literal.ml
+++ b/js/literal.ml
@@ -22,7 +22,6 @@ let float64_bits value =
     (Int64.to_int32 value, Int64.to_int32 (Int64.shift_right_logical value 32))
 
 let float32 value = Float32 value
-
 let float64 value = Float64 value
 
 (* This makes our `t` public so we can match on it *)

--- a/js/module.ml
+++ b/js/module.ml
@@ -5,38 +5,29 @@ module Feature = struct
   type t = int
 
   let mvp : t = global ##. binaryen ##. Features ##. MVP
-
   let atomics : t = global ##. binaryen ##. Features ##. Atomics
-
   let bulk_memory : t = global ##. binaryen ##. Features ##. BulkMemory
-
   let mutable_globals : t = global ##. binaryen ##. Features ##. MutableGlobals
 
   let nontrapping_fp_to_int : t =
     global ##. binaryen ##. Features ##. NontrappingFPToInt
 
   let sign_ext : t = global ##. binaryen ##. Features ##. SignExt
-
   let simd128 : t = global ##. binaryen ##. Features ##. SIMD128
 
   let exception_handling : t =
     global ##. binaryen ##. Features ##. ExceptionHandling
 
   let tail_call : t = global ##. binaryen ##. Features ##. TailCall
-
   let reference_types : t = global ##. binaryen ##. Features ##. ReferenceTypes
-
   let multivalue : t = global ##. binaryen ##. Features ##. Multivalue
-
   let gc : t = global ##. binaryen ##. Features ##. GC
-
   let memory64 : t = global ##. binaryen ##. Features ##. Memory64
 
   let typed_function_references : t =
     global ##. binaryen ##. Features ##. TypedFunctionReferences
 
   let relaxed_simd : t = global ##. binaryen ##. Features ##. RelaxedSIMD
-
   let all : t = global ##. binaryen ##. Features ##. All
 end
 
@@ -44,13 +35,11 @@ external u8a_to_bytes : 'a -> bytes = "caml_bytes_of_array"
 
 (* TODO: Verify this converts to bytes correctly? *)
 external bytes_to_u8a : bytes -> 'a = "caml_array_of_bytes"
-
 external string_to_u8a : string -> 'a = "caml_array_of_string"
 
 type t
 
 let create () = new_obj global ##. binaryen ##. Module [||]
-
 let dispose wasm_mod = ignore (meth_call wasm_mod "dispose" [||])
 
 (* TODO: Check the unit8Array conversion *)
@@ -72,7 +61,6 @@ let print_asmjs wasm_mod =
   print_string (to_string asm)
 
 let validate wasm_mod = meth_call wasm_mod "validate" [||]
-
 let optimize wasm_mod = meth_call wasm_mod "optimize" [||]
 
 let get_features wasm_mod =

--- a/js/module.ml
+++ b/js/module.ml
@@ -28,6 +28,15 @@ module Feature = struct
 
   let multivalue : t = global ##. binaryen ##. Features ##. Multivalue
 
+  let gc : t = global ##. binaryen ##. Features ##. GC
+
+  let memory64 : t = global ##. binaryen ##. Features ##. Memory64
+
+  let typed_function_references : t =
+    global ##. binaryen ##. Features ##. TypedFunctionReferences
+
+  let relaxed_simd : t = global ##. binaryen ##. Features ##. RelaxedSIMD
+
   let all : t = global ##. binaryen ##. Features ##. All
 end
 

--- a/js/op.ml
+++ b/js/op.ml
@@ -3,53 +3,29 @@ open Js_of_ocaml.Js.Unsafe
 type t = int
 
 let clz_int32 : t = global ##. binaryen ##. Operations ##. ClzInt32
-
 let ctz_int32 : t = global ##. binaryen ##. Operations ##. CtzInt32
-
 let popcnt_int32 : t = global ##. binaryen ##. Operations ##. PopcntInt32
-
 let neg_float32 : t = global ##. binaryen ##. Operations ##. NegFloat32
-
 let abs_float32 : t = global ##. binaryen ##. Operations ##. AbsFloat32
-
 let ceil_float32 : t = global ##. binaryen ##. Operations ##. CeilFloat32
-
 let floor_float32 : t = global ##. binaryen ##. Operations ##. FloorFloat32
-
 let trunc_float32 : t = global ##. binaryen ##. Operations ##. TruncFloat32
-
 let nearest_float32 : t = global ##. binaryen ##. Operations ##. NearestFloat32
-
 let sqrt_float32 : t = global ##. binaryen ##. Operations ##. SqrtFloat32
-
 let eq_z_int32 : t = global ##. binaryen ##. Operations ##. EqZInt32
-
 let clz_int64 : t = global ##. binaryen ##. Operations ##. ClzInt64
-
 let ctz_int64 : t = global ##. binaryen ##. Operations ##. CtzInt64
-
 let popcnt_int64 : t = global ##. binaryen ##. Operations ##. PopcntInt64
-
 let neg_float64 : t = global ##. binaryen ##. Operations ##. NegFloat64
-
 let abs_float64 : t = global ##. binaryen ##. Operations ##. AbsFloat64
-
 let ceil_float64 : t = global ##. binaryen ##. Operations ##. CeilFloat64
-
 let floor_float64 : t = global ##. binaryen ##. Operations ##. FloorFloat64
-
 let trunc_float64 : t = global ##. binaryen ##. Operations ##. TruncFloat64
-
 let nearest_float64 : t = global ##. binaryen ##. Operations ##. NearestFloat64
-
 let sqrt_float64 : t = global ##. binaryen ##. Operations ##. SqrtFloat64
-
 let eq_z_int64 : t = global ##. binaryen ##. Operations ##. EqZInt64
-
 let extend_s_int32 : t = global ##. binaryen ##. Operations ##. ExtendSInt32
-
 let extend_u_int32 : t = global ##. binaryen ##. Operations ##. ExtendUInt32
-
 let wrap_int64 : t = global ##. binaryen ##. Operations ##. WrapInt64
 
 let trunc_s_float32_to_int32 : t =
@@ -107,7 +83,6 @@ let convert_u_int64_to_float64 : t =
   global ##. binaryen ##. Operations ##. ConvertUInt64ToFloat64
 
 let promote_float32 : t = global ##. binaryen ##. Operations ##. PromoteFloat32
-
 let demote_float64 : t = global ##. binaryen ##. Operations ##. DemoteFloat64
 
 let reinterpret_int32 : t =
@@ -117,179 +92,97 @@ let reinterpret_int64 : t =
   global ##. binaryen ##. Operations ##. ReinterpretInt64
 
 let extend_s8_int32 : t = global ##. binaryen ##. Operations ##. ExtendS8Int32
-
 let extend_s16_int32 : t = global ##. binaryen ##. Operations ##. ExtendS16Int32
-
 let extend_s8_int64 : t = global ##. binaryen ##. Operations ##. ExtendS8Int64
-
 let extend_s16_int64 : t = global ##. binaryen ##. Operations ##. ExtendS16Int64
-
 let extend_s32_int64 : t = global ##. binaryen ##. Operations ##. ExtendS32Int64
-
 let add_int32 : t = global ##. binaryen ##. Operations ##. AddInt32
-
 let sub_int32 : t = global ##. binaryen ##. Operations ##. SubInt32
-
 let mul_int32 : t = global ##. binaryen ##. Operations ##. MulInt32
-
 let div_s_int32 : t = global ##. binaryen ##. Operations ##. DivSInt32
-
 let div_u_int32 : t = global ##. binaryen ##. Operations ##. DivUInt32
-
 let rem_s_int32 : t = global ##. binaryen ##. Operations ##. RemSInt32
-
 let rem_u_int32 : t = global ##. binaryen ##. Operations ##. RemUInt32
-
 let and_int32 : t = global ##. binaryen ##. Operations ##. AndInt32
-
 let or_int32 : t = global ##. binaryen ##. Operations ##. OrInt32
-
 let xor_int32 : t = global ##. binaryen ##. Operations ##. XorInt32
-
 let shl_int32 : t = global ##. binaryen ##. Operations ##. ShlInt32
-
 let shr_u_int32 : t = global ##. binaryen ##. Operations ##. ShrUInt32
-
 let shr_s_int32 : t = global ##. binaryen ##. Operations ##. ShrSInt32
-
 let rot_l_int32 : t = global ##. binaryen ##. Operations ##. RotLInt32
-
 let rot_r_int32 : t = global ##. binaryen ##. Operations ##. RotRInt32
-
 let eq_int32 : t = global ##. binaryen ##. Operations ##. EqInt32
-
 let ne_int32 : t = global ##. binaryen ##. Operations ##. NeInt32
-
 let lt_s_int32 : t = global ##. binaryen ##. Operations ##. LtSInt32
-
 let lt_u_int32 : t = global ##. binaryen ##. Operations ##. LtUInt32
-
 let le_s_int32 : t = global ##. binaryen ##. Operations ##. LeSInt32
-
 let le_u_int32 : t = global ##. binaryen ##. Operations ##. LeUInt32
-
 let gt_s_int32 : t = global ##. binaryen ##. Operations ##. GtSInt32
-
 let gt_u_int32 : t = global ##. binaryen ##. Operations ##. GtUInt32
-
 let ge_s_int32 : t = global ##. binaryen ##. Operations ##. GeSInt32
-
 let ge_u_int32 : t = global ##. binaryen ##. Operations ##. GeUInt32
-
 let add_int64 : t = global ##. binaryen ##. Operations ##. AddInt64
-
 let sub_int64 : t = global ##. binaryen ##. Operations ##. SubInt64
-
 let mul_int64 : t = global ##. binaryen ##. Operations ##. MulInt64
-
 let div_s_int64 : t = global ##. binaryen ##. Operations ##. DivSInt64
-
 let div_u_int64 : t = global ##. binaryen ##. Operations ##. DivUInt64
-
 let rem_s_int64 : t = global ##. binaryen ##. Operations ##. RemSInt64
-
 let rem_u_int64 : t = global ##. binaryen ##. Operations ##. RemUInt64
-
 let and_int64 : t = global ##. binaryen ##. Operations ##. AndInt64
-
 let or_int64 : t = global ##. binaryen ##. Operations ##. OrInt64
-
 let xor_int64 : t = global ##. binaryen ##. Operations ##. XorInt64
-
 let shl_int64 : t = global ##. binaryen ##. Operations ##. ShlInt64
-
 let shr_u_int64 : t = global ##. binaryen ##. Operations ##. ShrUInt64
-
 let shr_s_int64 : t = global ##. binaryen ##. Operations ##. ShrSInt64
-
 let rot_l_int64 : t = global ##. binaryen ##. Operations ##. RotLInt64
-
 let rot_r_int64 : t = global ##. binaryen ##. Operations ##. RotRInt64
-
 let eq_int64 : t = global ##. binaryen ##. Operations ##. EqInt64
-
 let ne_int64 : t = global ##. binaryen ##. Operations ##. NeInt64
-
 let lt_s_int64 : t = global ##. binaryen ##. Operations ##. LtSInt64
-
 let lt_u_int64 : t = global ##. binaryen ##. Operations ##. LtUInt64
-
 let le_s_int64 : t = global ##. binaryen ##. Operations ##. LeSInt64
-
 let le_u_int64 : t = global ##. binaryen ##. Operations ##. LeUInt64
-
 let gt_s_int64 : t = global ##. binaryen ##. Operations ##. GtSInt64
-
 let gt_u_int64 : t = global ##. binaryen ##. Operations ##. GtUInt64
-
 let ge_s_int64 : t = global ##. binaryen ##. Operations ##. GeSInt64
-
 let ge_u_int64 : t = global ##. binaryen ##. Operations ##. GeUInt64
-
 let add_float32 : t = global ##. binaryen ##. Operations ##. AddFloat32
-
 let sub_float32 : t = global ##. binaryen ##. Operations ##. SubFloat32
-
 let mul_float32 : t = global ##. binaryen ##. Operations ##. MulFloat32
-
 let div_float32 : t = global ##. binaryen ##. Operations ##. DivFloat32
 
 let copy_sign_float32 : t =
   global ##. binaryen ##. Operations ##. CopySignFloat32
 
 let min_float32 : t = global ##. binaryen ##. Operations ##. MinFloat32
-
 let max_float32 : t = global ##. binaryen ##. Operations ##. MaxFloat32
-
 let eq_float32 : t = global ##. binaryen ##. Operations ##. EqFloat32
-
 let ne_float32 : t = global ##. binaryen ##. Operations ##. NeFloat32
-
 let lt_float32 : t = global ##. binaryen ##. Operations ##. LtFloat32
-
 let le_float32 : t = global ##. binaryen ##. Operations ##. LeFloat32
-
 let gt_float32 : t = global ##. binaryen ##. Operations ##. GtFloat32
-
 let ge_float32 : t = global ##. binaryen ##. Operations ##. GeFloat32
-
 let add_float64 : t = global ##. binaryen ##. Operations ##. AddFloat64
-
 let sub_float64 : t = global ##. binaryen ##. Operations ##. SubFloat64
-
 let mul_float64 : t = global ##. binaryen ##. Operations ##. MulFloat64
-
 let div_float64 : t = global ##. binaryen ##. Operations ##. DivFloat64
 
 let copy_sign_float64 : t =
   global ##. binaryen ##. Operations ##. CopySignFloat64
 
 let min_float64 : t = global ##. binaryen ##. Operations ##. MinFloat64
-
 let max_float64 : t = global ##. binaryen ##. Operations ##. MaxFloat64
-
 let eq_float64 : t = global ##. binaryen ##. Operations ##. EqFloat64
-
 let ne_float64 : t = global ##. binaryen ##. Operations ##. NeFloat64
-
 let lt_float64 : t = global ##. binaryen ##. Operations ##. LtFloat64
-
 let le_float64 : t = global ##. binaryen ##. Operations ##. LeFloat64
-
 let gt_float64 : t = global ##. binaryen ##. Operations ##. GtFloat64
-
 let ge_float64 : t = global ##. binaryen ##. Operations ##. GeFloat64
-
 let atomic_rmw_add : t = global ##. binaryen ##. Operations ##. AtomicRMWAdd
-
 let atomic_rmw_sub : t = global ##. binaryen ##. Operations ##. AtomicRMWSub
-
 let atomic_rmw_and : t = global ##. binaryen ##. Operations ##. AtomicRMWAnd
-
 let atomic_rmw_or : t = global ##. binaryen ##. Operations ##. AtomicRMWOr
-
 let atomic_rmw_xor : t = global ##. binaryen ##. Operations ##. AtomicRMWXor
-
 let atomic_rmw_xchg : t = global ##. binaryen ##. Operations ##. AtomicRMWXchg
 
 let trunc_sat_s_float32_to_int32 : t =
@@ -371,104 +264,57 @@ let replace_lane_vec_f64x2 : t =
   global ##. binaryen ##. Operations ##. ReplaceLaneVecF64x2
 
 let eq_vec_i8x16 : t = global ##. binaryen ##. Operations ##. EqVecI8x16
-
 let ne_vec_i8x16 : t = global ##. binaryen ##. Operations ##. NeVecI8x16
-
 let lt_s_vec_i8x16 : t = global ##. binaryen ##. Operations ##. LtSVecI8x16
-
 let lt_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. LtUVecI8x16
-
 let gt_s_vec_i8x16 : t = global ##. binaryen ##. Operations ##. GtSVecI8x16
-
 let gt_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. GtUVecI8x16
-
 let le_s_vec_i8x16 : t = global ##. binaryen ##. Operations ##. LeSVecI8x16
-
 let le_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. LeUVecI8x16
-
 let ge_s_vec_i8x16 : t = global ##. binaryen ##. Operations ##. GeSVecI8x16
-
 let ge_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. GeUVecI8x16
-
 let eq_vec_i16x8 : t = global ##. binaryen ##. Operations ##. EqVecI16x8
-
 let ne_vec_i16x8 : t = global ##. binaryen ##. Operations ##. NeVecI16x8
-
 let lt_s_vec_i16x8 : t = global ##. binaryen ##. Operations ##. LtSVecI16x8
-
 let lt_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. LtUVecI16x8
-
 let gt_s_vec_i16x8 : t = global ##. binaryen ##. Operations ##. GtSVecI16x8
-
 let gt_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. GtUVecI16x8
-
 let le_s_vec_i16x8 : t = global ##. binaryen ##. Operations ##. LeSVecI16x8
-
 let le_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. LeUVecI16x8
-
 let ge_s_vec_i16x8 : t = global ##. binaryen ##. Operations ##. GeSVecI16x8
-
 let ge_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. GeUVecI16x8
-
 let eq_vec_i32x4 : t = global ##. binaryen ##. Operations ##. EqVecI32x4
-
 let ne_vec_i32x4 : t = global ##. binaryen ##. Operations ##. NeVecI32x4
-
 let lt_s_vec_i32x4 : t = global ##. binaryen ##. Operations ##. LtSVecI32x4
-
 let lt_u_vec_i32x4 : t = global ##. binaryen ##. Operations ##. LtUVecI32x4
-
 let gt_s_vec_i32x4 : t = global ##. binaryen ##. Operations ##. GtSVecI32x4
-
 let gt_u_vec_i32x4 : t = global ##. binaryen ##. Operations ##. GtUVecI32x4
-
 let le_s_vec_i32x4 : t = global ##. binaryen ##. Operations ##. LeSVecI32x4
-
 let le_u_vec_i32x4 : t = global ##. binaryen ##. Operations ##. LeUVecI32x4
-
 let ge_s_vec_i32x4 : t = global ##. binaryen ##. Operations ##. GeSVecI32x4
-
 let ge_u_vec_i32x4 : t = global ##. binaryen ##. Operations ##. GeUVecI32x4
-
 let eq_vec_f32x4 : t = global ##. binaryen ##. Operations ##. EqVecF32x4
-
 let ne_vec_f32x4 : t = global ##. binaryen ##. Operations ##. NeVecF32x4
-
 let lt_vec_f32x4 : t = global ##. binaryen ##. Operations ##. LtVecF32x4
-
 let gt_vec_f32x4 : t = global ##. binaryen ##. Operations ##. GtVecF32x4
-
 let le_vec_f32x4 : t = global ##. binaryen ##. Operations ##. LeVecF32x4
-
 let ge_vec_f32x4 : t = global ##. binaryen ##. Operations ##. GeVecF32x4
-
 let eq_vec_f64x2 : t = global ##. binaryen ##. Operations ##. EqVecF64x2
-
 let ne_vec_f64x2 : t = global ##. binaryen ##. Operations ##. NeVecF64x2
-
 let lt_vec_f64x2 : t = global ##. binaryen ##. Operations ##. LtVecF64x2
-
 let gt_vec_f64x2 : t = global ##. binaryen ##. Operations ##. GtVecF64x2
-
 let le_vec_f64x2 : t = global ##. binaryen ##. Operations ##. LeVecF64x2
-
 let ge_vec_f64x2 : t = global ##. binaryen ##. Operations ##. GeVecF64x2
-
 let not_vec128 : t = global ##. binaryen ##. Operations ##. NotVec128
-
 let and_vec128 : t = global ##. binaryen ##. Operations ##. AndVec128
-
 let or_vec128 : t = global ##. binaryen ##. Operations ##. OrVec128
-
 let xor_vec128 : t = global ##. binaryen ##. Operations ##. XorVec128
-
 let and_not_vec128 : t = global ##. binaryen ##. Operations ##. AndNotVec128
 
 let bitselect_vec128 : t =
   global ##. binaryen ##. Operations ##. BitselectVec128
 
 let abs_vec_i8x16 : t = global ##. binaryen ##. Operations ##. AbsVecI8x16
-
 let neg_vec_i8x16 : t = global ##. binaryen ##. Operations ##. NegVecI8x16
 
 let all_true_vec_i8x16 : t =
@@ -478,11 +324,8 @@ let bitmask_vec_i8x16 : t =
   global ##. binaryen ##. Operations ##. BitmaskVecI8x16
 
 let shl_vec_i8x16 : t = global ##. binaryen ##. Operations ##. ShlVecI8x16
-
 let shr_s_vec_i8x16 : t = global ##. binaryen ##. Operations ##. ShrSVecI8x16
-
 let shr_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. ShrUVecI8x16
-
 let add_vec_i8x16 : t = global ##. binaryen ##. Operations ##. AddVecI8x16
 
 let add_sat_s_vec_i8x16 : t =
@@ -500,17 +343,11 @@ let sub_sat_u_vec_i8x16 : t =
   global ##. binaryen ##. Operations ##. SubSatUVecI8x16
 
 let min_s_vec_i8x16 : t = global ##. binaryen ##. Operations ##. MinSVecI8x16
-
 let min_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. MinUVecI8x16
-
 let max_s_vec_i8x16 : t = global ##. binaryen ##. Operations ##. MaxSVecI8x16
-
 let max_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. MaxUVecI8x16
-
 let avgr_u_vec_i8x16 : t = global ##. binaryen ##. Operations ##. AvgrUVecI8x16
-
 let abs_vec_i16x8 : t = global ##. binaryen ##. Operations ##. AbsVecI16x8
-
 let neg_vec_i16x8 : t = global ##. binaryen ##. Operations ##. NegVecI16x8
 
 let all_true_vec_i16x8 : t =
@@ -520,11 +357,8 @@ let bitmask_vec_i16x8 : t =
   global ##. binaryen ##. Operations ##. BitmaskVecI16x8
 
 let shl_vec_i16x8 : t = global ##. binaryen ##. Operations ##. ShlVecI16x8
-
 let shr_s_vec_i16x8 : t = global ##. binaryen ##. Operations ##. ShrSVecI16x8
-
 let shr_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. ShrUVecI16x8
-
 let add_vec_i16x8 : t = global ##. binaryen ##. Operations ##. AddVecI16x8
 
 let add_sat_s_vec_i16x8 : t =
@@ -542,19 +376,12 @@ let sub_sat_u_vec_i16x8 : t =
   global ##. binaryen ##. Operations ##. SubSatUVecI16x8
 
 let mul_vec_i16x8 : t = global ##. binaryen ##. Operations ##. MulVecI16x8
-
 let min_s_vec_i16x8 : t = global ##. binaryen ##. Operations ##. MinSVecI16x8
-
 let min_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. MinUVecI16x8
-
 let max_s_vec_i16x8 : t = global ##. binaryen ##. Operations ##. MaxSVecI16x8
-
 let max_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. MaxUVecI16x8
-
 let avgr_u_vec_i16x8 : t = global ##. binaryen ##. Operations ##. AvgrUVecI16x8
-
 let abs_vec_i32x4 : t = global ##. binaryen ##. Operations ##. AbsVecI32x4
-
 let neg_vec_i32x4 : t = global ##. binaryen ##. Operations ##. NegVecI32x4
 
 let all_true_vec_i32x4 : t =
@@ -564,99 +391,57 @@ let bitmask_vec_i32x4 : t =
   global ##. binaryen ##. Operations ##. BitmaskVecI32x4
 
 let shl_vec_i32x4 : t = global ##. binaryen ##. Operations ##. ShlVecI32x4
-
 let shr_s_vec_i32x4 : t = global ##. binaryen ##. Operations ##. ShrSVecI32x4
-
 let shr_u_vec_i32x4 : t = global ##. binaryen ##. Operations ##. ShrUVecI32x4
-
 let add_vec_i32x4 : t = global ##. binaryen ##. Operations ##. AddVecI32x4
-
 let sub_vec_i32x4 : t = global ##. binaryen ##. Operations ##. SubVecI32x4
-
 let mul_vec_i32x4 : t = global ##. binaryen ##. Operations ##. MulVecI32x4
-
 let min_s_vec_i32x4 : t = global ##. binaryen ##. Operations ##. MinSVecI32x4
-
 let min_u_vec_i32x4 : t = global ##. binaryen ##. Operations ##. MinUVecI32x4
-
 let max_s_vec_i32x4 : t = global ##. binaryen ##. Operations ##. MaxSVecI32x4
-
 let max_u_vec_i32x4 : t = global ##. binaryen ##. Operations ##. MaxUVecI32x4
 
 let dot_s_vec_i16x8_to_vec_i32x4 : t =
   global ##. binaryen ##. Operations ##. DotSVecI16x8ToVecI32x4
 
 let neg_vec_i64x2 : t = global ##. binaryen ##. Operations ##. NegVecI64x2
-
 let shl_vec_i64x2 : t = global ##. binaryen ##. Operations ##. ShlVecI64x2
-
 let shr_s_vec_i64x2 : t = global ##. binaryen ##. Operations ##. ShrSVecI64x2
-
 let shr_u_vec_i64x2 : t = global ##. binaryen ##. Operations ##. ShrUVecI64x2
-
 let add_vec_i64x2 : t = global ##. binaryen ##. Operations ##. AddVecI64x2
-
 let sub_vec_i64x2 : t = global ##. binaryen ##. Operations ##. SubVecI64x2
-
 let mul_vec_i64x2 : t = global ##. binaryen ##. Operations ##. MulVecI64x2
-
 let abs_vec_f32x4 : t = global ##. binaryen ##. Operations ##. AbsVecF32x4
-
 let neg_vec_f32x4 : t = global ##. binaryen ##. Operations ##. NegVecF32x4
-
 let sqrt_vec_f32x4 : t = global ##. binaryen ##. Operations ##. SqrtVecF32x4
-
 let add_vec_f32x4 : t = global ##. binaryen ##. Operations ##. AddVecF32x4
-
 let sub_vec_f32x4 : t = global ##. binaryen ##. Operations ##. SubVecF32x4
-
 let mul_vec_f32x4 : t = global ##. binaryen ##. Operations ##. MulVecF32x4
-
 let div_vec_f32x4 : t = global ##. binaryen ##. Operations ##. DivVecF32x4
-
 let min_vec_f32x4 : t = global ##. binaryen ##. Operations ##. MinVecF32x4
-
 let max_vec_f32x4 : t = global ##. binaryen ##. Operations ##. MaxVecF32x4
-
 let p_min_vec_f32x4 : t = global ##. binaryen ##. Operations ##. PMinVecF32x4
-
 let p_max_vec_f32x4 : t = global ##. binaryen ##. Operations ##. PMaxVecF32x4
-
 let ceil_vec_f32x4 : t = global ##. binaryen ##. Operations ##. CeilVecF32x4
-
 let floor_vec_f32x4 : t = global ##. binaryen ##. Operations ##. FloorVecF32x4
-
 let trunc_vec_f32x4 : t = global ##. binaryen ##. Operations ##. TruncVecF32x4
 
 let nearest_vec_f32x4 : t =
   global ##. binaryen ##. Operations ##. NearestVecF32x4
 
 let abs_vec_f64x2 : t = global ##. binaryen ##. Operations ##. AbsVecF64x2
-
 let neg_vec_f64x2 : t = global ##. binaryen ##. Operations ##. NegVecF64x2
-
 let sqrt_vec_f64x2 : t = global ##. binaryen ##. Operations ##. SqrtVecF64x2
-
 let add_vec_f64x2 : t = global ##. binaryen ##. Operations ##. AddVecF64x2
-
 let sub_vec_f64x2 : t = global ##. binaryen ##. Operations ##. SubVecF64x2
-
 let mul_vec_f64x2 : t = global ##. binaryen ##. Operations ##. MulVecF64x2
-
 let div_vec_f64x2 : t = global ##. binaryen ##. Operations ##. DivVecF64x2
-
 let min_vec_f64x2 : t = global ##. binaryen ##. Operations ##. MinVecF64x2
-
 let max_vec_f64x2 : t = global ##. binaryen ##. Operations ##. MaxVecF64x2
-
 let p_min_vec_f64x2 : t = global ##. binaryen ##. Operations ##. PMinVecF64x2
-
 let p_max_vec_f64x2 : t = global ##. binaryen ##. Operations ##. PMaxVecF64x2
-
 let ceil_vec_f64x2 : t = global ##. binaryen ##. Operations ##. CeilVecF64x2
-
 let floor_vec_f64x2 : t = global ##. binaryen ##. Operations ##. FloorVecF64x2
-
 let trunc_vec_f64x2 : t = global ##. binaryen ##. Operations ##. TruncVecF64x2
 
 let nearest_vec_f64x2 : t =
@@ -687,19 +472,11 @@ let narrow_u_vec_i32x4_to_vec_i16x8 : t =
   global ##. binaryen ##. Operations ##. NarrowUVecI32x4ToVecI16x8
 
 let swizzle_vec8x16 : t = global ##. binaryen ##. Operations ##. SwizzleVec8x16
-
 let ref_is_null : t = global ##. binaryen ##. Operations ##. RefIsNull
-
 let ref_is_func : t = global ##. binaryen ##. Operations ##. RefIsFunc
-
 let ref_is_data : t = global ##. binaryen ##. Operations ##. RefIsData
-
 let ref_is_i31 : t = global ##. binaryen ##. Operations ##. RefIsI31
-
 let ref_as_non_null : t = global ##. binaryen ##. Operations ##. RefAsNonNull
-
 let ref_as_func : t = global ##. binaryen ##. Operations ##. RefAsFunc
-
 let ref_as_data : t = global ##. binaryen ##. Operations ##. RefAsData
-
 let ref_as_i31 : t = global ##. binaryen ##. Operations ##. RefAsI31

--- a/js/postlude.js
+++ b/js/postlude.js
@@ -1,2 +1,0 @@
-// Attach binaryen to globalThis because JSOO wraps in an iife
-globalThis.binaryen = module.exports;

--- a/js/prelude.js
+++ b/js/prelude.js
@@ -1,11 +1,2 @@
-if (typeof module === 'undefined') {
-  module = {};
-}
-
-if (typeof exports === 'undefined') {
-  exports = {};
-}
-
-if (typeof module.exports === 'undefined') {
-  module.exports = exports;
-}
+// Attach binaryen to globalThis so binaryen will register itself on the object
+globalThis.binaryen = {}

--- a/js/type.ml
+++ b/js/type.ml
@@ -4,23 +4,14 @@ open Js_of_ocaml.Js.Unsafe
 type t = int
 
 let none : t = global##.binaryen##.none
-
 let int32 : t = global##.binaryen##.i32
-
 let int64 : t = global##.binaryen##.i64
-
 let float32 : t = global##.binaryen##.f32
-
 let float64 : t = global##.binaryen##.f64
-
 let vec128 : t = global##.binaryen##.v128
-
 let funcref : t = global##.binaryen##.funcref
-
 let externref : t = global##.binaryen##.externref
-
 let unreachable : t = global##.binaryen##.unreachable
-
 let auto : t = global##.binaryen##.auto
 
 let create typs =

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "ocaml": ">= 4.12.0",
-    "@grain/libbinaryen": "^102.0.4",
+    "@grain/libbinaryen": "^103.0.1",
     "@opam/dune": "^2.9.1",
     "@opam/dune-configurator": "^2.9.1",
     "@opam/js_of_ocaml": ">= 3.10.0 < 4.0.0",

--- a/src/binaryen_stubs_expressions.c
+++ b/src/binaryen_stubs_expressions.c
@@ -1708,3 +1708,253 @@ caml_binaryen_tuple_extract_set_tuple(value _exp, value _value) {
   BinaryenTupleExtractSetTuple(exp, val);
   CAMLreturn(Val_unit);
 }
+
+// Ref operations
+CAMLprim value
+caml_binaryen_ref_null(value _module, value _ty) {
+  CAMLparam2(_module, _ty);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  BinaryenType ty = BinaryenType_val(_ty);
+  BinaryenExpressionRef exp = BinaryenRefNull(module, ty);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+CAMLprim value
+caml_binaryen_ref_is(value _module, value _op, value _value) {
+  CAMLparam3(_module, _op, _value);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  BinaryenOp op = BinaryenOp_val(_op);
+  BinaryenExpressionRef val = BinaryenExpressionRef_val(_value);
+  BinaryenExpressionRef exp = BinaryenRefIs(module, op, val);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+CAMLprim value
+caml_binaryen_ref_as(value _module, value _op, value _value) {
+  CAMLparam3(_module, _op, _value);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  BinaryenOp op = BinaryenOp_val(_op);
+  BinaryenExpressionRef val = BinaryenExpressionRef_val(_value);
+  BinaryenExpressionRef exp = BinaryenRefAs(module, op, val);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+CAMLprim value
+caml_binaryen_ref_func(value _module, value _name, value _ty) {
+  CAMLparam3(_module, _name, _ty);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  char* name = Safe_String_val(_name);
+  BinaryenType ty = BinaryenType_val(_ty);
+  BinaryenExpressionRef exp = BinaryenRefFunc(module, name, ty);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+CAMLprim value
+caml_binaryen_ref_eq(value _module, value _left, value _right) {
+  CAMLparam3(_module, _left, _right);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  BinaryenExpressionRef left = BinaryenExpressionRef_val(_left);
+  BinaryenExpressionRef right = BinaryenExpressionRef_val(_right);
+  BinaryenExpressionRef exp = BinaryenRefEq(module, left, right);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+// Table operations
+CAMLprim value
+caml_binaryen_table_get(value _module, value _name, value _index, value _ty) {
+  CAMLparam4(_module, _name, _index, _ty);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  char* name = Safe_String_val(_name);
+  BinaryenExpressionRef index = BinaryenExpressionRef_val(_index);
+  BinaryenType ty = BinaryenType_val(_ty);
+  BinaryenExpressionRef exp = BinaryenTableGet(module, name, index, ty);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+CAMLprim value
+caml_binaryen_table_set(value _module, value _name, value _index, value _value) {
+  CAMLparam4(_module, _name, _index, _value);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  char* name = Safe_String_val(_name);
+  BinaryenExpressionRef index = BinaryenExpressionRef_val(_index);
+  BinaryenExpressionRef val = BinaryenExpressionRef_val(_value);
+  BinaryenExpressionRef exp = BinaryenTableSet(module, name, index, val);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+CAMLprim value
+caml_binaryen_table_size(value _module, value _name) {
+  CAMLparam2(_module, _name);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  char* name = Safe_String_val(_name);
+  BinaryenExpressionRef exp = BinaryenTableSize(module, name);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+CAMLprim value
+caml_binaryen_table_grow(value _module, value _name, value _value, value _delta) {
+  CAMLparam4(_module, _name, _value, _delta);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  char* name = Safe_String_val(_name);
+  BinaryenExpressionRef val = BinaryenExpressionRef_val(_value);
+  BinaryenExpressionRef delta = BinaryenExpressionRef_val(_delta);
+  BinaryenExpressionRef exp = BinaryenTableGrow(module, name, val, delta);
+  CAMLreturn(alloc_BinaryenExpressionRef(exp));
+}
+
+// TableGet operations
+CAMLprim value
+caml_binaryen_tableget_get_table(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  const char* name = BinaryenTableGetGetTable(exp);
+  CAMLreturn(caml_copy_string(name));
+}
+
+CAMLprim value
+caml_binaryen_tableget_set_table(value _exp, value _table) {
+  CAMLparam2(_exp, _table);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  char* table = Safe_String_val(_table);
+  BinaryenTableGetSetTable(exp, table);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value
+caml_binaryen_tableget_get_index(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef index = BinaryenTableGetGetIndex(exp);
+  CAMLreturn(alloc_BinaryenExpressionRef(index));
+}
+
+CAMLprim value
+caml_binaryen_tableget_set_index(value _exp, value _index) {
+  CAMLparam2(_exp, _index);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef index = BinaryenExpressionRef_val(_index);
+  BinaryenTableGetSetIndex(exp, index);
+  CAMLreturn(Val_unit);
+}
+
+// TableSet operations
+CAMLprim value
+caml_binaryen_tableset_get_table(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  const char* name = BinaryenTableSetGetTable(exp);
+  CAMLreturn(caml_copy_string(name));
+}
+
+CAMLprim value
+caml_binaryen_tableset_set_table(value _exp, value _table) {
+  CAMLparam2(_exp, _table);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  char* table = Safe_String_val(_table);
+  BinaryenTableSetSetTable(exp, table);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value
+caml_binaryen_tableset_get_index(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef index = BinaryenTableSetGetIndex(exp);
+  CAMLreturn(alloc_BinaryenExpressionRef(index));
+}
+
+CAMLprim value
+caml_binaryen_tableset_set_index(value _exp, value _index) {
+  CAMLparam2(_exp, _index);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef index = BinaryenExpressionRef_val(_index);
+  BinaryenTableSetSetIndex(exp, index);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value
+caml_binaryen_tableset_get_value(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef val = BinaryenTableSetGetValue(exp);
+  CAMLreturn(alloc_BinaryenExpressionRef(val));
+}
+
+CAMLprim value
+caml_binaryen_tableset_set_value(value _exp, value _value) {
+  CAMLparam2(_exp, _value);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef val = BinaryenExpressionRef_val(_value);
+  BinaryenTableSetSetValue(exp, val);
+  CAMLreturn(Val_unit);
+}
+
+// TableSize operations
+CAMLprim value
+caml_binaryen_tablesize_get_table(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  const char* name = BinaryenTableSizeGetTable(exp);
+  CAMLreturn(caml_copy_string(name));
+}
+
+CAMLprim value
+caml_binaryen_tablesize_set_table(value _exp, value _table) {
+  CAMLparam2(_exp, _table);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  char* table = Safe_String_val(_table);
+  BinaryenTableSizeSetTable(exp, table);
+  CAMLreturn(Val_unit);
+}
+
+// TableGrow operations
+CAMLprim value
+caml_binaryen_tablegrow_get_table(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  const char* name = BinaryenTableGrowGetTable(exp);
+  CAMLreturn(caml_copy_string(name));
+}
+
+CAMLprim value
+caml_binaryen_tablegrow_set_table(value _exp, value _table) {
+  CAMLparam2(_exp, _table);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  char* table = Safe_String_val(_table);
+  BinaryenTableGrowSetTable(exp, table);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value
+caml_binaryen_tablegrow_get_value(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef val = BinaryenTableGrowGetValue(exp);
+  CAMLreturn(alloc_BinaryenExpressionRef(val));
+}
+
+CAMLprim value
+caml_binaryen_tablegrow_set_value(value _exp, value _value) {
+  CAMLparam2(_exp, _value);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef val = BinaryenExpressionRef_val(_value);
+  BinaryenTableGrowSetValue(exp, val);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value
+caml_binaryen_tablegrow_get_delta(value _exp) {
+  CAMLparam1(_exp);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef delta = BinaryenTableGrowGetDelta(exp);
+  CAMLreturn(alloc_BinaryenExpressionRef(delta));
+}
+
+CAMLprim value
+caml_binaryen_tablegrow_set_delta(value _exp, value _delta) {
+  CAMLparam2(_exp, _delta);
+  BinaryenExpressionRef exp = BinaryenExpressionRef_val(_exp);
+  BinaryenExpressionRef delta = BinaryenExpressionRef_val(_delta);
+  BinaryenTableGrowSetDelta(exp, delta);
+  CAMLreturn(Val_unit);
+}

--- a/src/binaryen_stubs_features.c
+++ b/src/binaryen_stubs_features.c
@@ -90,6 +90,30 @@ caml_binaryen_feature_multivalue(value unit) {
 }
 
 CAMLprim value
+caml_binaryen_feature_gc(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureGC()));
+}
+
+CAMLprim value
+caml_binaryen_feature_memory64(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureMemory64()));
+}
+
+CAMLprim value
+caml_binaryen_feature_typed_function_references(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureTypedFunctionReferences()));
+}
+
+CAMLprim value
+caml_binaryen_feature_relaxed_simd(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureRelaxedSIMD()));
+}
+
+CAMLprim value
 caml_binaryen_feature_all(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_int(BinaryenFeatureAll()));

--- a/src/element_segment.ml
+++ b/src/element_segment.ml
@@ -1,7 +1,6 @@
 type t
 
 external get_name : t -> string = "caml_binaryen_element_segment_get_name"
-
 external get_table : t -> string = "caml_binaryen_element_segment_get_table"
 
 external get_offset : t -> Expression.t

--- a/src/export.ml
+++ b/src/export.ml
@@ -28,9 +28,7 @@ external get_export_by_index : Module.t -> int -> t
   = "caml_binaryen_get_export_by_index"
 
 external get_name : t -> string = "caml_binaryen_export_get_name"
-
 external get_value : t -> string = "caml_binaryen_export_get_value"
-
 external external_function : unit -> int = "caml_binaryen_external_function"
 
 let external_function = external_function ()

--- a/src/expression.ml
+++ b/src/expression.ml
@@ -69,7 +69,6 @@ type kind =
   | RefAs
 
 external get_id : t -> int = "caml_binaryen_expression_get_id"
-
 external id_invalid : unit -> int = "caml_binaryen_expression_id_invalid"
 
 let id_invalid = id_invalid ()
@@ -426,7 +425,6 @@ external print : t -> unit = "caml_binaryen_expression_print"
 (** Print an expression to the console. *)
 
 external finalize : t -> unit = "caml_binaryen_expression_finalize"
-
 external copy : t -> Module.t -> t = "caml_binaryen_expression_copy"
 
 (** Expression manipulation *)
@@ -440,11 +438,8 @@ module Block = struct
     make wasm_mod name exprs return_type
 
   external get_name : t -> string option = "caml_binaryen_block_get_name"
-
   external set_name : t -> string -> unit = "caml_binaryen_block_set_name"
-
   external get_num_children : t -> int = "caml_binaryen_block_get_num_children"
-
   external get_child_at : t -> int -> t = "caml_binaryen_block_get_child_at"
 
   external set_child_at : t -> int -> t -> unit
@@ -464,15 +459,10 @@ module If = struct
   (** Module, condition, true branch, false branch. False branch may be null. *)
 
   external get_condition : t -> t = "caml_binaryen_if_get_condition"
-
   external set_condition : t -> t -> unit = "caml_binaryen_if_set_condition"
-
   external get_if_true : t -> t = "caml_binaryen_if_get_if_true"
-
   external set_if_true : t -> t -> unit = "caml_binaryen_if_set_if_true"
-
   external get_if_false : t -> t option = "caml_binaryen_if_get_if_false"
-
   external set_if_false : t -> t -> unit = "caml_binaryen_if_set_if_false"
 end
 
@@ -481,11 +471,8 @@ module Loop = struct
   (** Module, loop name, body. *)
 
   external get_name : t -> string = "caml_binaryen_loop_get_name"
-
   external set_name : t -> string -> unit = "caml_binaryen_loop_set_name"
-
   external get_body : t -> t = "caml_binaryen_loop_get_body"
-
   external set_body : t -> t -> unit = "caml_binaryen_loop_set_body"
 end
 
@@ -494,15 +481,10 @@ module Break = struct
   (** Module, block name, condition, result. Value and condition may be null. *)
 
   external get_name : t -> string = "caml_binaryen_break_get_name"
-
   external set_name : t -> string -> unit = "caml_binaryen_break_set_name"
-
   external get_condition : t -> t option = "caml_binaryen_break_get_condition"
-
   external set_condition : t -> t -> unit = "caml_binaryen_break_set_condition"
-
   external get_value : t -> t option = "caml_binaryen_break_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_break_set_value"
 end
 
@@ -512,7 +494,6 @@ module Switch = struct
   (** Module, branch names, default branch name, condition, value. Value may be null. *)
 
   external get_num_names : t -> int = "caml_binaryen_switch_get_num_names"
-
   external get_name_at : t -> int -> string = "caml_binaryen_switch_get_name_at"
 
   external set_name_at : t -> int -> string -> unit
@@ -533,11 +514,8 @@ module Switch = struct
     = "caml_binaryen_switch_set_default_name"
 
   external get_condition : t -> t = "caml_binaryen_switch_get_condition"
-
   external set_condition : t -> t -> unit = "caml_binaryen_switch_set_condition"
-
   external get_value : t -> t option = "caml_binaryen_switch_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_switch_set_value"
 end
 
@@ -551,11 +529,8 @@ module Call = struct
   (** Module, function name, params, return type. *)
 
   external get_target : t -> string = "caml_binaryen_call_get_target"
-
   external set_target : t -> string -> unit = "caml_binaryen_call_set_target"
-
   external get_num_operands : t -> int = "caml_binaryen_call_get_num_operands"
-
   external get_operand_at : t -> int -> t = "caml_binaryen_call_get_operand_at"
 
   external set_operand_at : t -> int -> t -> unit
@@ -570,7 +545,6 @@ module Call = struct
     = "caml_binaryen_call_remove_operand_at"
 
   external is_return : t -> bool = "caml_binaryen_call_is_return"
-
   external set_return : t -> bool -> unit = "caml_binaryen_call_set_return"
 end
 
@@ -628,7 +602,6 @@ module Local_set = struct
   (** Module, slot, value. *)
 
   external get_value : t -> t = "caml_binaryen_local_set_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_local_set_set_value"
 end
 
@@ -643,7 +616,6 @@ module Global_get = struct
   (** Module, name, type. *)
 
   external get_name : t -> string = "caml_binaryen_global_get_get_name"
-
   external set_name : t -> string -> unit = "caml_binaryen_global_get_set_name"
 end
 
@@ -652,11 +624,8 @@ module Global_set = struct
   (** Module, name, value. *)
 
   external get_name : t -> string = "caml_binaryen_global_set_get_name"
-
   external set_name : t -> string -> unit = "caml_binaryen_global_set_set_name"
-
   external get_value : t -> t = "caml_binaryen_global_set_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_global_set_set_value"
 end
 
@@ -669,7 +638,6 @@ module Load = struct
     make wasm_mod bytes signed offset align ty ptr
 
   external get_ptr : t -> t = "caml_binaryen_load_get_ptr"
-
   external set_ptr : t -> t -> unit = "caml_binaryen_load_set_ptr"
 end
 
@@ -679,11 +647,8 @@ module Store = struct
   (** Module, num_bytes, offset, align, ptr, value, type. *)
 
   external get_ptr : t -> t = "caml_binaryen_store_get_ptr"
-
   external set_ptr : t -> t -> unit = "caml_binaryen_store_set_ptr"
-
   external get_value : t -> t = "caml_binaryen_store_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_store_set_value"
 end
 
@@ -693,21 +658,15 @@ end
 
 module Unary = struct
   external make : Module.t -> Op.t -> t -> t = "caml_binaryen_unary"
-
   external get_value : t -> t = "caml_binaryen_unary_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_unary_set_value"
 end
 
 module Binary = struct
   external make : Module.t -> Op.t -> t -> t -> t = "caml_binaryen_binary"
-
   external get_left : t -> t = "caml_binaryen_binary_get_left"
-
   external set_left : t -> t -> unit = "caml_binaryen_binary_set_left"
-
   external get_right : t -> t = "caml_binaryen_binary_get_right"
-
   external set_right : t -> t -> unit = "caml_binaryen_binary_set_right"
 end
 
@@ -719,31 +678,22 @@ module Select = struct
   let make wasm_mod cond tru fals = make wasm_mod cond tru fals Type.auto
 
   external get_if_true : t -> t = "caml_binaryen_select_get_if_true"
-
   external set_if_true : t -> t -> unit = "caml_binaryen_select_set_if_true"
-
   external get_if_false : t -> t = "caml_binaryen_select_get_if_false"
-
   external set_if_false : t -> t -> unit = "caml_binaryen_select_set_if_false"
-
   external get_condition : t -> t = "caml_binaryen_select_get_condition"
-
   external set_condition : t -> t -> unit = "caml_binaryen_select_set_condition"
 end
 
 module Drop = struct
   external make : Module.t -> t -> t = "caml_binaryen_drop"
-
   external get_value : t -> t = "caml_binaryen_drop_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_drop_set_value"
 end
 
 module Return = struct
   external make : Module.t -> t -> t = "caml_binaryen_return"
-
   external get_value : t -> t = "caml_binaryen_return_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_return_set_value"
 end
 
@@ -753,9 +703,7 @@ end
 
 module Memory_grow = struct
   external make : Module.t -> t -> t = "caml_binaryen_memory_grow"
-
   external get_delta : t -> t = "caml_binaryen_memory_grow_get_delta"
-
   external set_delta : t -> t -> unit = "caml_binaryen_memory_grow_set_delta"
 end
 
@@ -764,15 +712,10 @@ module Memory_copy = struct
   (** Module, destination, source, size. *)
 
   external get_dest : t -> t = "caml_binaryen_memory_copy_get_dest"
-
   external set_dest : t -> t -> unit = "caml_binaryen_memory_copy_set_dest"
-
   external get_source : t -> t = "caml_binaryen_memory_copy_get_source"
-
   external set_source : t -> t -> unit = "caml_binaryen_memory_copy_set_source"
-
   external get_size : t -> t = "caml_binaryen_memory_copy_get_size"
-
   external set_size : t -> t -> unit = "caml_binaryen_memory_copy_set_size"
 end
 
@@ -781,15 +724,10 @@ module Memory_fill = struct
   (** Module, destination, value, size. *)
 
   external get_dest : t -> t = "caml_binaryen_memory_fill_get_dest"
-
   external set_dest : t -> t -> unit = "caml_binaryen_memory_fill_set_dest"
-
   external get_value : t -> t = "caml_binaryen_memory_fill_get_value"
-
   external set_value : t -> t -> unit = "caml_binaryen_memory_fill_set_value"
-
   external get_size : t -> t = "caml_binaryen_memory_fill_get_size"
-
   external set_size : t -> t -> unit = "caml_binaryen_memory_fill_set_size"
 end
 
@@ -821,7 +759,6 @@ module Tuple_extract = struct
   (** Module, tuple, index *)
 
   external get_tuple : t -> t = "caml_binaryen_tuple_extract_get_tuple"
-
   external set_tuple : t -> t -> unit = "caml_binaryen_tuple_extract_set_tuple"
 end
 

--- a/src/expression.ml
+++ b/src/expression.ml
@@ -842,3 +842,97 @@ module Null = struct
   external make : unit -> t = "caml_binaryen_null_expression"
   (** A null reference. *)
 end
+
+module Ref = struct
+  external null : Module.t -> Type.t -> t = "caml_binaryen_ref_null"
+  (** Module, type *)
+
+  external is : Module.t -> Op.t -> t -> t = "caml_binaryen_ref_is"
+  (** Module, op, value *)
+
+  external as_ : Module.t -> Op.t -> t -> t = "caml_binaryen_ref_as"
+  (** Module, op, value *)
+
+  external func : Module.t -> string -> Type.t -> t = "caml_binaryen_ref_func"
+  (** Module, func, type *)
+
+  external eq : Module.t -> t -> t -> t = "caml_binaryen_ref_eq"
+  (** Module, left, right *)
+end
+
+module Table = struct
+  external get : Module.t -> string -> t -> Type.t -> t
+    = "caml_binaryen_table_get"
+  (** Module, name, index, type *)
+
+  external set : Module.t -> string -> t -> t -> t = "caml_binaryen_table_set"
+  (** Module, name, index, value *)
+
+  external size : Module.t -> string -> t = "caml_binaryen_table_size"
+  (** Module, name *)
+
+  external grow : Module.t -> string -> t -> t -> t = "caml_binaryen_table_grow"
+  (** Module, name, value, delta *)
+end
+
+module Table_get = struct
+  external get_table : t -> string = "caml_binaryen_tableget_get_table"
+  (** Gets the name of the table being accessed by a `Table.get` expression. *)
+
+  external set_table : t -> string -> unit = "caml_binaryen_tableget_set_table"
+  (** Gets the name of the table being accessed by a `Table.get` expression. *)
+
+  external get_index : t -> t = "caml_binaryen_tableget_get_index"
+  (** Gets the index expression of a `Table.get` expression. *)
+
+  external set_index : t -> t -> unit = "caml_binaryen_tableget_set_index"
+  (** Gets the index expression of a `Table.get` expression. *)
+end
+
+module Table_set = struct
+  external get_table : t -> string = "caml_binaryen_tableset_get_table"
+  (** Gets the name of the table being accessed by a `Table.set` expression. *)
+
+  external set_table : t -> string -> unit = "caml_binaryen_tableset_set_table"
+  (** Sets the name of the table being accessed by a `Table.set` expression. *)
+
+  external get_index : t -> t = "caml_binaryen_tableset_get_index"
+  (** Gets the index expression of a `Table.set` expression. *)
+
+  external set_index : t -> t -> unit = "caml_binaryen_tableset_set_index"
+  (** Sets the index expression of a `Table.set` expression. *)
+
+  external get_value : t -> t = "caml_binaryen_tableset_get_value"
+  (** Gets the value expression of a `Table.set` expression. *)
+
+  external set_value : t -> t -> unit = "caml_binaryen_tableset_set_value"
+  (** Sets the value expression of a `Table.set` expression. *)
+end
+
+module Table_size = struct
+  external get_table : t -> string = "caml_binaryen_tablesize_get_table"
+  (** Gets the name of the table being accessed by a `Table.size` expression. *)
+
+  external set_table : t -> string -> unit = "caml_binaryen_tablesize_set_table"
+  (** Sets the name of the table being accessed by a `Table.size` expression. *)
+end
+
+module Table_grow = struct
+  external get_table : t -> string = "caml_binaryen_tablegrow_get_table"
+  (** Gets the name of the table being accessed by a `Table.grow` expression. *)
+
+  external set_table : t -> string -> unit = "caml_binaryen_tablegrow_set_table"
+  (** Gets the name of the table being accessed by a `Table.grow` expression. *)
+
+  external get_value : t -> t = "caml_binaryen_tablegrow_get_value"
+  (** Gets the value expression of a `Table.grow` expression. *)
+
+  external set_value : t -> t -> unit = "caml_binaryen_tablegrow_set_value"
+  (** Sets the value expression of a `Table.grow` expression. *)
+
+  external get_delta : t -> t = "caml_binaryen_tablegrow_get_delta"
+  (** Gets the delta of a `Table.grow` expression. *)
+
+  external set_delta : t -> t -> unit = "caml_binaryen_tablegrow_set_delta"
+  (** Sets the delta of a `Table.grow` expression. *)
+end

--- a/src/function.ml
+++ b/src/function.ml
@@ -19,17 +19,11 @@ external remove_function : Module.t -> string -> unit
   = "caml_binaryen_remove_function"
 
 external get_num_functions : Module.t -> int = "caml_binaryen_get_num_functions"
-
 external get_name : t -> string = "caml_binaryen_function_get_name"
-
 external get_params : t -> Type.t = "caml_binaryen_function_get_params"
-
 external get_results : t -> Type.t = "caml_binaryen_function_get_results"
-
 external get_num_vars : t -> int = "caml_binaryen_function_get_num_vars"
-
 external get_var : t -> int -> Type.t = "caml_binaryen_function_get_var"
-
 external get_body : t -> Expression.t = "caml_binaryen_function_get_body"
 
 external set_body : t -> Expression.t -> unit

--- a/src/global.ml
+++ b/src/global.ml
@@ -15,9 +15,7 @@ external get_global_by_index : Module.t -> int -> t
   = "caml_binaryen_get_global_by_index"
 
 external get_name : t -> string = "caml_binaryen_global_get_name"
-
 external get_type : t -> Type.t = "caml_binaryen_global_get_type"
-
 external is_mutable : t -> bool = "caml_binaryen_global_is_mutable"
 
 external get_init_expr : t -> Expression.t

--- a/src/literal.ml
+++ b/src/literal.ml
@@ -1,11 +1,8 @@
 type t
 
 external int32 : int32 -> t = "caml_binaryen_literal_int32"
-
 external int64 : int64 -> t = "caml_binaryen_literal_int64"
-
 external float32_bits : int32 -> t = "caml_binaryen_literal_float32_bits"
-
 external float64_bits : int64 -> t = "caml_binaryen_literal_float64_bits"
 
 let float32 n = float32_bits @@ Int32.bits_of_float n

--- a/src/module.ml
+++ b/src/module.ml
@@ -1,5 +1,4 @@
 let _ = Callback.register "array_of_list" Array.of_list
-
 let _ = Callback.register "array_length" Array.length
 
 type t
@@ -76,22 +75,16 @@ module Feature = struct
 end
 
 external create : unit -> t = "caml_binaryen_module_create"
-
 external dispose : t -> unit = "caml_binaryen_module_dispose"
 
 external add_custom_section : t -> string -> string -> unit
   = "caml_binaryen_add_custom_section"
 
 external parse : string -> t = "caml_binaryen_module_parse"
-
 external print : t -> unit = "caml_binaryen_module_print"
-
 external print_asmjs : t -> unit = "caml_binaryen_module_print_asmjs"
-
 external validate : t -> int = "caml_binaryen_module_validate"
-
 external optimize : t -> unit = "caml_binaryen_module_optimize"
-
 external get_features : t -> int = "caml_binaryen_module_get_features"
 
 let get_features wasm_mod =
@@ -120,9 +113,7 @@ external write : t -> string option -> bytes * string option
   = "caml_binaryen_module_write"
 
 external write_text : t -> string = "caml_binaryen_module_write_text"
-
 external read : bytes -> t = "caml_binaryen_module_read"
-
 external interpret : t -> unit = "caml_binaryen_module_interpret"
 
 external add_debug_info_filename : t -> string -> int

--- a/src/module.ml
+++ b/src/module.ml
@@ -53,6 +53,23 @@ module Feature = struct
 
   let multivalue = multivalue ()
 
+  external gc : unit -> t = "caml_binaryen_feature_gc"
+
+  let gc = gc ()
+
+  external memory64 : unit -> t = "caml_binaryen_feature_memory64"
+
+  let memory64 = memory64 ()
+
+  external typed_function_references : unit -> t
+    = "caml_binaryen_feature_typed_function_references"
+
+  let typed_function_references = typed_function_references ()
+
+  external relaxed_simd : unit -> t = "caml_binaryen_feature_relaxed_simd"
+
+  let relaxed_simd = relaxed_simd ()
+
   external all : unit -> t = "caml_binaryen_feature_all"
 
   let all = all ()

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -1,13 +1,8 @@
 external get_optimize_level : unit -> int = "caml_binaryen_get_optimize_level"
-
 external set_optimize_level : int -> unit = "caml_binaryen_set_optimize_level"
-
 external get_shrink_level : unit -> int = "caml_binaryen_get_shrink_level"
-
 external set_shrink_level : int -> unit = "caml_binaryen_set_shrink_level"
-
 external get_debug_info : unit -> bool = "caml_binaryen_get_debug_info"
-
 external set_debug_info : bool -> unit = "caml_binaryen_set_debug_info"
 
 external get_low_memory_unused : unit -> bool
@@ -41,5 +36,4 @@ external set_one_caller_inline_max_size : int -> unit
   = "caml_binaryen_set_one_caller_inline_max_size"
 
 external set_colors_enabled : bool -> unit = "caml_binaryen_set_colors_enabled"
-
 external are_colors_enabled : unit -> bool = "caml_binaryen_are_colors_enabled"

--- a/src/type.ml
+++ b/src/type.ml
@@ -41,5 +41,4 @@ external auto : unit -> t = "caml_binaryen_type_auto"
 let auto = auto ()
 
 external create : t array -> t = "caml_binaryen_type_create"
-
 external expand : t -> t array = "caml_binaryen_type_expand"

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,3 +1,11 @@
+(table.get $table
+ (i32.const 0)
+)
+(table.size $table)
+(table.grow $table
+ (ref.null func)
+ (i32.const 0)
+)
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))

--- a/test/test.ml
+++ b/test/test.ml
@@ -137,7 +137,26 @@ let byts, _ = Module.write wasm_mod None
 
 let new_mod = Module.read byts
 
-let _ = Module.set_features new_mod [ Module.Feature.all ]
+let _ =
+  Module.set_features new_mod
+    [
+      Module.Feature.mvp;
+      Module.Feature.atomics;
+      Module.Feature.bulk_memory;
+      Module.Feature.mutable_globals;
+      Module.Feature.nontrapping_fp_to_int;
+      Module.Feature.sign_ext;
+      Module.Feature.simd128;
+      Module.Feature.exception_handling;
+      Module.Feature.tail_call;
+      Module.Feature.reference_types;
+      Module.Feature.multivalue;
+      Module.Feature.gc;
+      Module.Feature.memory64;
+      Module.Feature.typed_function_references;
+      Module.Feature.relaxed_simd;
+      Module.Feature.all;
+    ]
 
 let _ = Module.validate new_mod
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -62,6 +62,30 @@ let start =
 
 let _ = Export.add_function_export wasm_mod "adder" "adder"
 let _ = Table.add_table wasm_mod "table" 1 1 Type.funcref
+let funcref_expr1 = Expression.Ref.func wasm_mod "adder" Type.funcref
+
+let _ =
+  Expression.Table.set wasm_mod "table"
+    (Expression.Const.make wasm_mod (Literal.int32 0l))
+    funcref_expr1
+
+let funcref_expr2 =
+  Expression.Table.get wasm_mod "table"
+    (Expression.Const.make wasm_mod (Literal.int32 0l))
+    Type.funcref
+
+let _ = Expression.print funcref_expr2
+let table_size = Expression.Table.size wasm_mod "table"
+let _ = Expression.print table_size
+let table_name = Expression.Table_size.get_table table_size
+let _ = Expression.Table_size.set_table table_size table_name
+let null_ref = Expression.Ref.null wasm_mod Type.funcref
+
+let table_grow =
+  Expression.Table.grow wasm_mod "table" null_ref
+    (Expression.Const.make wasm_mod (Literal.int32 0l))
+
+let _ = Expression.print table_grow
 
 let _ =
   Global.add_global wasm_mod "max_int64" Type.int64 false

--- a/test/test.ml
+++ b/test/test.ml
@@ -2,44 +2,29 @@ open Binaryen
 
 (* Testing colors enable *)
 let _ = assert (Settings.are_colors_enabled () == true)
-
 let _ = Settings.set_colors_enabled false
-
 let _ = assert (Settings.are_colors_enabled () == false)
-
 let _ = Settings.set_colors_enabled true
 
 (* Testing debug_info enable *)
 let _ = assert (Settings.get_debug_info () == false)
-
 let _ = Settings.set_debug_info true
-
 let _ = assert (Settings.get_debug_info () == true)
-
 let _ = Settings.set_debug_info false
 
 (* Testing low_memory_unused enable *)
 let _ = assert (Settings.get_low_memory_unused () == false)
-
 let _ = Settings.set_low_memory_unused true
-
 let _ = assert (Settings.get_low_memory_unused () == true)
-
 let _ = Settings.set_low_memory_unused false
-
 let wasm_mod = Module.create ()
-
 let _ = Module.set_features wasm_mod [ Module.Feature.all ]
 
 (* Create function type for i32 (i32, i32) *)
 let params () = Type.create [| Type.int32; Type.int32 |]
-
 let results = Type.int32
-
 let x () = Expression.Local_get.make wasm_mod 0 Type.int32
-
 let y () = Expression.Local_get.make wasm_mod 1 Type.int32
-
 let load = Expression.Load.make wasm_mod 1 ~signed:true 0 0 Type.int32 (y ())
 
 let select =
@@ -76,7 +61,6 @@ let start =
     (Expression.Drop.make wasm_mod call_adder)
 
 let _ = Export.add_function_export wasm_mod "adder" "adder"
-
 let _ = Table.add_table wasm_mod "table" 1 1 Type.funcref
 
 let _ =
@@ -92,7 +76,6 @@ let _ =
     (Expression.Const.make wasm_mod (Literal.int32 0l))
 
 let _ = Function.set_start wasm_mod start
-
 let _ = Memory.set_memory wasm_mod 1 Memory.unlimited "memory" [] false
 
 (* Create an imported "write" function i32 (externref, i32, i32) *)
@@ -128,13 +111,11 @@ let _ = Module.print wasm_mod
 (* 2. Optimize, then print the module *)
 
 let _ = Module.optimize wasm_mod
-
 let _ = Module.print wasm_mod
 
 (* 3. Copy previous module bytes into new module, validate, and print *)
 
 let byts, _ = Module.write wasm_mod None
-
 let new_mod = Module.read byts
 
 let _ =
@@ -159,11 +140,9 @@ let _ =
     ]
 
 let _ = Module.validate new_mod
-
 let _ = Module.print new_mod
 
 (* Dispose the modules 👋 *)
 
 let _ = Module.dispose wasm_mod
-
 let _ = Module.dispose new_mod

--- a/virtual/element_segment.mli
+++ b/virtual/element_segment.mli
@@ -1,11 +1,7 @@
 type t
 
 val get_name : t -> string
-
 val get_table : t -> string
-
 val get_offset : t -> Expression.t
-
 val get_length : t -> int
-
 val get_data : t -> int -> string

--- a/virtual/export.mli
+++ b/virtual/export.mli
@@ -1,33 +1,18 @@
 type t
 
 val add_function_export : Module.t -> string -> string -> t
-
 val add_table_export : Module.t -> string -> string -> t
-
 val add_memory_export : Module.t -> string -> string -> t
-
 val add_global_export : Module.t -> string -> string -> t
-
 val get_export : Module.t -> string -> t
-
 val remove_export : Module.t -> string -> unit
-
 val get_num_exports : Module.t -> int
-
 val get_export_by_index : Module.t -> int -> t
-
 val get_name : t -> string
-
 val get_value : t -> string
-
 val external_function : int
-
 val external_table : int
-
 val external_memory : int
-
 val external_global : int
-
 val external_tag : int
-
 val export_get_kind : t -> int

--- a/virtual/expression.mli
+++ b/virtual/expression.mli
@@ -421,3 +421,96 @@ end
 module Null : sig
   val make : unit -> t
 end
+
+module Ref : sig
+  val null : Module.t -> Type.t -> t
+  (** Module, type *)
+
+  val is : Module.t -> Op.t -> t -> t
+  (** Module, op, value *)
+
+  val as_ : Module.t -> Op.t -> t -> t
+  (** Module, op, value *)
+
+  val func : Module.t -> string -> Type.t -> t
+  (** Module, func, type *)
+
+  val eq : Module.t -> t -> t -> t
+  (** Module, left, right *)
+end
+
+module Table : sig
+  val get : Module.t -> string -> t -> Type.t -> t
+  (** Module, name, index, type *)
+
+  val set : Module.t -> string -> t -> t -> t
+  (** Module, name, index, value *)
+
+  val size : Module.t -> string -> t
+  (** Module, name *)
+
+  val grow : Module.t -> string -> t -> t -> t
+  (** Module, name, value, delta *)
+end
+
+module Table_get : sig
+  val get_table : t -> string
+  (** Gets the name of the table being accessed by a `Table.get` expression. *)
+
+  val set_table : t -> string -> unit
+  (** Gets the name of the table being accessed by a `Table.get` expression. *)
+
+  val get_index : t -> t
+  (** Gets the index expression of a `Table.get` expression. *)
+
+  val set_index : t -> t -> unit
+  (** Gets the index expression of a `Table.get` expression. *)
+end
+
+module Table_set : sig
+  val get_table : t -> string
+  (** Gets the name of the table being accessed by a `Table.set` expression. *)
+
+  val set_table : t -> string -> unit
+  (** Sets the name of the table being accessed by a `Table.set` expression. *)
+
+  val get_index : t -> t
+  (** Gets the index expression of a `Table.set` expression. *)
+
+  val set_index : t -> t -> unit
+  (** Sets the index expression of a `Table.set` expression. *)
+
+  val get_value : t -> t
+  (** Gets the value expression of a `Table.set` expression. *)
+
+  val set_value : t -> t -> unit
+  (** Sets the value expression of a `Table.set` expression. *)
+end
+
+module Table_size : sig
+  val get_table : t -> string
+  (** Gets the name of the table being accessed by a `Table.size` expression. *)
+
+  val set_table : t -> string -> unit
+  (** Sets the name of the table being accessed by a `Table.size` expression. *)
+end
+
+module Table_grow : sig
+  val get_table : t -> string
+  (** Gets the name of the table being accessed by a `Table.grow` expression. *)
+
+  val set_table : t -> string -> unit
+  (** Gets the name of the table being accessed by a `Table.grow` expression. *)
+
+  val get_value : t -> t
+  (** Gets the value expression of a `Table.grow` expression. *)
+
+  val set_value : t -> t -> unit
+  (** Sets the value expression of a `Table.grow` expression. *)
+
+  val get_delta : t -> t
+  (** Gets the delta of a `Table.grow` expression. *)
+
+  val set_delta : t -> t -> unit
+  (** Sets the delta of a `Table.grow` expression. *)
+end

--- a/virtual/expression.mli
+++ b/virtual/expression.mli
@@ -69,160 +69,97 @@ type kind =
   | RefAs
 
 val get_kind : t -> kind
-
 val print : t -> unit
-
 val finalize : t -> unit
-
 val copy : t -> Module.t -> t
 
 (* Expression operations *)
 
 module Block : sig
   val make : ?return_type:Type.t -> Module.t -> string -> t list -> t
-
   val get_name : t -> string option
-
   val set_name : t -> string -> unit
-
   val get_num_children : t -> int
-
   val get_child_at : t -> int -> t
-
   val set_child_at : t -> int -> t -> unit
-
   val append_child : t -> t -> int
-
   val insert_child_at : t -> int -> t -> unit
-
   val remove_child_at : t -> int -> t
 end
 
 module If : sig
   val make : Module.t -> t -> t -> t -> t
-
   val get_condition : t -> t
-
   val set_condition : t -> t -> unit
-
   val get_if_true : t -> t
-
   val set_if_true : t -> t -> unit
-
   val get_if_false : t -> t option
-
   val set_if_false : t -> t -> unit
 end
 
 module Loop : sig
   val make : Module.t -> string -> t -> t
-
   val get_name : t -> string
-
   val set_name : t -> string -> unit
-
   val get_body : t -> t
-
   val set_body : t -> t -> unit
 end
 
 module Break : sig
   val make : Module.t -> string -> t -> t -> t
-
   val get_name : t -> string
-
   val set_name : t -> string -> unit
-
   val get_condition : t -> t option
-
   val set_condition : t -> t -> unit
-
   val get_value : t -> t option
-
   val set_value : t -> t -> unit
 end
 
 module Switch : sig
   val make : Module.t -> string list -> string -> t -> t -> t
-
   val get_num_names : t -> int
-
   val get_name_at : t -> int -> string
-
   val set_name_at : t -> int -> string -> unit
-
   val append_name : t -> string -> int
-
   val insert_name_at : t -> int -> string -> unit
-
   val remove_name_at : t -> int -> string
-
   val get_default_name : t -> string option
-
   val set_default_name : t -> string -> unit
-
   val get_condition : t -> t
-
   val set_condition : t -> t -> unit
-
   val get_value : t -> t option
-
   val set_value : t -> t -> unit
 end
 
 module Call : sig
   val make : Module.t -> string -> t list -> Type.t -> t
-
   val make_return : Module.t -> string -> t list -> Type.t -> t
-
   val get_target : t -> string
-
   val set_target : t -> string -> unit
-
   val get_num_operands : t -> int
-
   val get_operand_at : t -> int -> t
-
   val set_operand_at : t -> int -> t -> unit
-
   val append_operand : t -> t -> int
-
   val insert_operand_at : t -> int -> t -> unit
-
   val remove_operand_at : t -> int -> t
-
   val is_return : t -> bool
-
   val set_return : t -> bool -> unit
 end
 
 module Call_indirect : sig
   val make : Module.t -> string -> t -> t list -> Type.t -> Type.t -> t
-
   val make_return : Module.t -> string -> t -> t list -> Type.t -> Type.t -> t
-
   val get_target : t -> t
-
   val set_target : t -> t -> unit
-
   val get_table : t -> string
-
   val set_table : t -> string -> unit
-
   val get_num_operands : t -> int
-
   val get_operand_at : t -> int -> t
-
   val set_operand_at : t -> int -> t -> unit
-
   val append_operand : t -> t -> int
-
   val insert_operand_at : t -> int -> t -> unit
-
   val remove_operand_at : t -> int -> t
-
   val is_return : t -> bool
-
   val set_return : t -> bool -> unit
 end
 
@@ -232,9 +169,7 @@ end
 
 module Local_set : sig
   val make : Module.t -> int -> t -> t
-
   val get_value : t -> t
-
   val set_value : t -> t -> unit
 end
 
@@ -244,41 +179,29 @@ end
 
 module Global_get : sig
   val make : Module.t -> string -> Type.t -> t
-
   val get_name : t -> string
-
   val set_name : t -> string -> unit
 end
 
 module Global_set : sig
   val make : Module.t -> string -> t -> t
-
   val get_name : t -> string
-
   val set_name : t -> string -> unit
-
   val get_value : t -> t
-
   val set_value : t -> t -> unit
 end
 
 module Load : sig
   val make : Module.t -> int -> ?signed:bool -> int -> int -> Type.t -> t -> t
-
   val get_ptr : t -> t
-
   val set_ptr : t -> t -> unit
 end
 
 module Store : sig
   val make : Module.t -> int -> int -> int -> t -> t -> Type.t -> t
-
   val get_ptr : t -> t
-
   val set_ptr : t -> t -> unit
-
   val get_value : t -> t
-
   val set_value : t -> t -> unit
 end
 
@@ -288,53 +211,37 @@ end
 
 module Unary : sig
   val make : Module.t -> Op.t -> t -> t
-
   val get_value : t -> t
-
   val set_value : t -> t -> unit
 end
 
 module Binary : sig
   val make : Module.t -> Op.t -> t -> t -> t
-
   val get_left : t -> t
-
   val set_left : t -> t -> unit
-
   val get_right : t -> t
-
   val set_right : t -> t -> unit
 end
 
 module Select : sig
   val make : Module.t -> t -> t -> t -> t
-
   val get_if_true : t -> t
-
   val set_if_true : t -> t -> unit
-
   val get_if_false : t -> t
-
   val set_if_false : t -> t -> unit
-
   val get_condition : t -> t
-
   val set_condition : t -> t -> unit
 end
 
 module Drop : sig
   val make : Module.t -> t -> t
-
   val get_value : t -> t
-
   val set_value : t -> t -> unit
 end
 
 module Return : sig
   val make : Module.t -> t -> t
-
   val get_value : t -> t
-
   val set_value : t -> t -> unit
 end
 
@@ -344,65 +251,43 @@ end
 
 module Memory_grow : sig
   val make : Module.t -> t -> t
-
   val get_delta : t -> t
-
   val set_delta : t -> t -> unit
 end
 
 module Memory_copy : sig
   val make : Module.t -> t -> t -> t -> t
-
   val get_dest : t -> t
-
   val set_dest : t -> t -> unit
-
   val get_source : t -> t
-
   val set_source : t -> t -> unit
-
   val get_size : t -> t
-
   val set_size : t -> t -> unit
 end
 
 module Memory_fill : sig
   val make : Module.t -> t -> t -> t -> t
-
   val get_dest : t -> t
-
   val set_dest : t -> t -> unit
-
   val get_value : t -> t
-
   val set_value : t -> t -> unit
-
   val get_size : t -> t
-
   val set_size : t -> t -> unit
 end
 
 module Tuple_make : sig
   val make : Module.t -> t list -> t
-
   val get_num_operands : t -> int
-
   val get_operand_at : t -> int -> t
-
   val set_operand_at : t -> int -> t -> unit
-
   val append_operand : t -> t -> int
-
   val insert_operand_at : t -> int -> t -> unit
-
   val remove_operand_at : t -> int -> t
 end
 
 module Tuple_extract : sig
   val make : Module.t -> t -> int -> t
-
   val get_tuple : t -> t
-
   val set_tuple : t -> t -> unit
 end
 

--- a/virtual/function.mli
+++ b/virtual/function.mli
@@ -4,27 +4,15 @@ val add_function :
   Module.t -> string -> Type.t -> Type.t -> Type.t array -> Expression.t -> t
 
 val set_start : Module.t -> t -> unit
-
 val set_debug_location : t -> Expression.t -> int -> int -> int -> unit
-
 val get_function : Module.t -> string -> t
-
 val get_function_by_index : Module.t -> int -> t
-
 val remove_function : Module.t -> string -> unit
-
 val get_num_functions : Module.t -> int
-
 val get_name : t -> string
-
 val get_params : t -> Type.t
-
 val get_results : t -> Type.t
-
 val get_num_vars : t -> int
-
 val get_var : t -> int -> Type.t
-
 val get_body : t -> Expression.t
-
 val set_body : t -> Expression.t -> unit

--- a/virtual/global.mli
+++ b/virtual/global.mli
@@ -1,19 +1,11 @@
 type t
 
 val add_global : Module.t -> string -> Type.t -> bool -> Expression.t -> t
-
 val get_global : Module.t -> string -> t
-
 val remove_global : Module.t -> string -> unit
-
 val get_num_globals : Module.t -> int
-
 val get_global_by_index : Module.t -> int -> t
-
 val get_name : t -> string
-
 val get_type : t -> Type.t
-
 val is_mutable : t -> bool
-
 val get_init_expr : t -> Expression.t

--- a/virtual/import.mli
+++ b/virtual/import.mli
@@ -2,16 +2,12 @@ val add_function_import :
   Module.t -> string -> string -> string -> Type.t -> Type.t -> unit
 
 val add_table_import : Module.t -> string -> string -> string -> unit
-
 val add_memory_import : Module.t -> string -> string -> string -> bool -> unit
 
 val add_global_import :
   Module.t -> string -> string -> string -> Type.t -> bool -> unit
 
 val function_import_get_module : Function.t -> string
-
 val global_import_get_module : Global.t -> string
-
 val function_import_get_base : Function.t -> string
-
 val global_import_get_base : Global.t -> string

--- a/virtual/literal.mli
+++ b/virtual/literal.mli
@@ -1,15 +1,10 @@
 type t
 
 val int32 : int32 -> t
-
 val int64 : int64 -> t
-
 val float32_bits : int32 -> t
-
 val float64_bits : int64 -> t
-
 val float32 : float -> t
-
 val float64 : float -> t
 
 (* Hacks for Binaryen.js stack allocations *)

--- a/virtual/module.mli
+++ b/virtual/module.mli
@@ -25,6 +25,14 @@ module Feature : sig
 
   val multivalue : t
 
+  val gc : t
+
+  val memory64 : t
+
+  val typed_function_references : t
+
+  val relaxed_simd : t
+
   val all : t
 end
 

--- a/virtual/module.mli
+++ b/virtual/module.mli
@@ -4,72 +4,39 @@ module Feature : sig
   type t
 
   val mvp : t
-
   val atomics : t
-
   val bulk_memory : t
-
   val mutable_globals : t
-
   val nontrapping_fp_to_int : t
-
   val sign_ext : t
-
   val simd128 : t
-
   val exception_handling : t
-
   val tail_call : t
-
   val reference_types : t
-
   val multivalue : t
-
   val gc : t
-
   val memory64 : t
-
   val typed_function_references : t
-
   val relaxed_simd : t
-
   val all : t
 end
 
 val create : unit -> t
-
 val dispose : t -> unit
-
 val add_custom_section : t -> string -> string -> unit
-
 val parse : string -> t
-
 val print : t -> unit
-
 val print_asmjs : t -> unit
-
 val validate : t -> int
-
 val optimize : t -> unit
-
 val get_features : t -> Feature.t list
-
 val set_features : t -> Feature.t list -> unit
-
 val run_passes : t -> string list -> unit
-
 val auto_drop : t -> unit
-
 val write : t -> string option -> bytes * string option
-
 val write_text : t -> string
-
 val read : bytes -> t
-
 val interpret : t -> unit
-
 val add_debug_info_filename : t -> string -> int
-
 val get_debug_info_filename : t -> int -> string
-
 val update_maps : t -> unit

--- a/virtual/op.mli
+++ b/virtual/op.mli
@@ -1,633 +1,318 @@
 type t
 
 val clz_int32 : t
-
 val ctz_int32 : t
-
 val popcnt_int32 : t
-
 val neg_float32 : t
-
 val abs_float32 : t
-
 val ceil_float32 : t
-
 val floor_float32 : t
-
 val trunc_float32 : t
-
 val nearest_float32 : t
-
 val sqrt_float32 : t
-
 val eq_z_int32 : t
-
 val clz_int64 : t
-
 val ctz_int64 : t
-
 val popcnt_int64 : t
-
 val neg_float64 : t
-
 val abs_float64 : t
-
 val ceil_float64 : t
-
 val floor_float64 : t
-
 val trunc_float64 : t
-
 val nearest_float64 : t
-
 val sqrt_float64 : t
-
 val eq_z_int64 : t
-
 val extend_s_int32 : t
-
 val extend_u_int32 : t
-
 val wrap_int64 : t
-
 val trunc_s_float32_to_int32 : t
-
 val trunc_s_float32_to_int64 : t
-
 val trunc_u_float32_to_int32 : t
-
 val trunc_u_float32_to_int64 : t
-
 val trunc_s_float64_to_int32 : t
-
 val trunc_s_float64_to_int64 : t
-
 val trunc_u_float64_to_int32 : t
-
 val trunc_u_float64_to_int64 : t
-
 val reinterpret_float32 : t
-
 val reinterpret_float64 : t
-
 val convert_s_int32_to_float32 : t
-
 val convert_s_int32_to_float64 : t
-
 val convert_u_int32_to_float32 : t
-
 val convert_u_int32_to_float64 : t
-
 val convert_s_int64_to_float32 : t
-
 val convert_s_int64_to_float64 : t
-
 val convert_u_int64_to_float32 : t
-
 val convert_u_int64_to_float64 : t
-
 val promote_float32 : t
-
 val demote_float64 : t
-
 val reinterpret_int32 : t
-
 val reinterpret_int64 : t
-
 val extend_s8_int32 : t
-
 val extend_s16_int32 : t
-
 val extend_s8_int64 : t
-
 val extend_s16_int64 : t
-
 val extend_s32_int64 : t
-
 val add_int32 : t
-
 val sub_int32 : t
-
 val mul_int32 : t
-
 val div_s_int32 : t
-
 val div_u_int32 : t
-
 val rem_s_int32 : t
-
 val rem_u_int32 : t
-
 val and_int32 : t
-
 val or_int32 : t
-
 val xor_int32 : t
-
 val shl_int32 : t
-
 val shr_u_int32 : t
-
 val shr_s_int32 : t
-
 val rot_l_int32 : t
-
 val rot_r_int32 : t
-
 val eq_int32 : t
-
 val ne_int32 : t
-
 val lt_s_int32 : t
-
 val lt_u_int32 : t
-
 val le_s_int32 : t
-
 val le_u_int32 : t
-
 val gt_s_int32 : t
-
 val gt_u_int32 : t
-
 val ge_s_int32 : t
-
 val ge_u_int32 : t
-
 val add_int64 : t
-
 val sub_int64 : t
-
 val mul_int64 : t
-
 val div_s_int64 : t
-
 val div_u_int64 : t
-
 val rem_s_int64 : t
-
 val rem_u_int64 : t
-
 val and_int64 : t
-
 val or_int64 : t
-
 val xor_int64 : t
-
 val shl_int64 : t
-
 val shr_u_int64 : t
-
 val shr_s_int64 : t
-
 val rot_l_int64 : t
-
 val rot_r_int64 : t
-
 val eq_int64 : t
-
 val ne_int64 : t
-
 val lt_s_int64 : t
-
 val lt_u_int64 : t
-
 val le_s_int64 : t
-
 val le_u_int64 : t
-
 val gt_s_int64 : t
-
 val gt_u_int64 : t
-
 val ge_s_int64 : t
-
 val ge_u_int64 : t
-
 val add_float32 : t
-
 val sub_float32 : t
-
 val mul_float32 : t
-
 val div_float32 : t
-
 val copy_sign_float32 : t
-
 val min_float32 : t
-
 val max_float32 : t
-
 val eq_float32 : t
-
 val ne_float32 : t
-
 val lt_float32 : t
-
 val le_float32 : t
-
 val gt_float32 : t
-
 val ge_float32 : t
-
 val add_float64 : t
-
 val sub_float64 : t
-
 val mul_float64 : t
-
 val div_float64 : t
-
 val copy_sign_float64 : t
-
 val min_float64 : t
-
 val max_float64 : t
-
 val eq_float64 : t
-
 val ne_float64 : t
-
 val lt_float64 : t
-
 val le_float64 : t
-
 val gt_float64 : t
-
 val ge_float64 : t
-
 val atomic_rmw_add : t
-
 val atomic_rmw_sub : t
-
 val atomic_rmw_and : t
-
 val atomic_rmw_or : t
-
 val atomic_rmw_xor : t
-
 val atomic_rmw_xchg : t
-
 val trunc_sat_s_float32_to_int32 : t
-
 val trunc_sat_s_float32_to_int64 : t
-
 val trunc_sat_u_float32_to_int32 : t
-
 val trunc_sat_u_float32_to_int64 : t
-
 val trunc_sat_s_float64_to_int32 : t
-
 val trunc_sat_s_float64_to_int64 : t
-
 val trunc_sat_u_float64_to_int32 : t
-
 val trunc_sat_u_float64_to_int64 : t
-
 val splat_vec_i8x16 : t
-
 val extract_lane_s_vec_i8x16 : t
-
 val extract_lane_u_vec_i8x16 : t
-
 val replace_lane_vec_i8x16 : t
-
 val splat_vec_i16x8 : t
-
 val extract_lane_s_vec_i16x8 : t
-
 val extract_lane_u_vec_i16x8 : t
-
 val replace_lane_vec_i16x8 : t
-
 val splat_vec_i32x4 : t
-
 val extract_lane_vec_i32x4 : t
-
 val replace_lane_vec_i32x4 : t
-
 val splat_vec_i64x2 : t
-
 val extract_lane_vec_i64x2 : t
-
 val replace_lane_vec_i64x2 : t
-
 val splat_vec_f32x4 : t
-
 val extract_lane_vec_f32x4 : t
-
 val replace_lane_vec_f32x4 : t
-
 val splat_vec_f64x2 : t
-
 val extract_lane_vec_f64x2 : t
-
 val replace_lane_vec_f64x2 : t
-
 val eq_vec_i8x16 : t
-
 val ne_vec_i8x16 : t
-
 val lt_s_vec_i8x16 : t
-
 val lt_u_vec_i8x16 : t
-
 val gt_s_vec_i8x16 : t
-
 val gt_u_vec_i8x16 : t
-
 val le_s_vec_i8x16 : t
-
 val le_u_vec_i8x16 : t
-
 val ge_s_vec_i8x16 : t
-
 val ge_u_vec_i8x16 : t
-
 val eq_vec_i16x8 : t
-
 val ne_vec_i16x8 : t
-
 val lt_s_vec_i16x8 : t
-
 val lt_u_vec_i16x8 : t
-
 val gt_s_vec_i16x8 : t
-
 val gt_u_vec_i16x8 : t
-
 val le_s_vec_i16x8 : t
-
 val le_u_vec_i16x8 : t
-
 val ge_s_vec_i16x8 : t
-
 val ge_u_vec_i16x8 : t
-
 val eq_vec_i32x4 : t
-
 val ne_vec_i32x4 : t
-
 val lt_s_vec_i32x4 : t
-
 val lt_u_vec_i32x4 : t
-
 val gt_s_vec_i32x4 : t
-
 val gt_u_vec_i32x4 : t
-
 val le_s_vec_i32x4 : t
-
 val le_u_vec_i32x4 : t
-
 val ge_s_vec_i32x4 : t
-
 val ge_u_vec_i32x4 : t
-
 val eq_vec_f32x4 : t
-
 val ne_vec_f32x4 : t
-
 val lt_vec_f32x4 : t
-
 val gt_vec_f32x4 : t
-
 val le_vec_f32x4 : t
-
 val ge_vec_f32x4 : t
-
 val eq_vec_f64x2 : t
-
 val ne_vec_f64x2 : t
-
 val lt_vec_f64x2 : t
-
 val gt_vec_f64x2 : t
-
 val le_vec_f64x2 : t
-
 val ge_vec_f64x2 : t
-
 val not_vec128 : t
-
 val and_vec128 : t
-
 val or_vec128 : t
-
 val xor_vec128 : t
-
 val and_not_vec128 : t
-
 val bitselect_vec128 : t
-
 val abs_vec_i8x16 : t
-
 val neg_vec_i8x16 : t
-
 val all_true_vec_i8x16 : t
-
 val bitmask_vec_i8x16 : t
-
 val shl_vec_i8x16 : t
-
 val shr_s_vec_i8x16 : t
-
 val shr_u_vec_i8x16 : t
-
 val add_vec_i8x16 : t
-
 val add_sat_s_vec_i8x16 : t
-
 val add_sat_u_vec_i8x16 : t
-
 val sub_vec_i8x16 : t
-
 val sub_sat_s_vec_i8x16 : t
-
 val sub_sat_u_vec_i8x16 : t
-
 val min_s_vec_i8x16 : t
-
 val min_u_vec_i8x16 : t
-
 val max_s_vec_i8x16 : t
-
 val max_u_vec_i8x16 : t
-
 val avgr_u_vec_i8x16 : t
-
 val abs_vec_i16x8 : t
-
 val neg_vec_i16x8 : t
-
 val all_true_vec_i16x8 : t
-
 val bitmask_vec_i16x8 : t
-
 val shl_vec_i16x8 : t
-
 val shr_s_vec_i16x8 : t
-
 val shr_u_vec_i16x8 : t
-
 val add_vec_i16x8 : t
-
 val add_sat_s_vec_i16x8 : t
-
 val add_sat_u_vec_i16x8 : t
-
 val sub_vec_i16x8 : t
-
 val sub_sat_s_vec_i16x8 : t
-
 val sub_sat_u_vec_i16x8 : t
-
 val mul_vec_i16x8 : t
-
 val min_s_vec_i16x8 : t
-
 val min_u_vec_i16x8 : t
-
 val max_s_vec_i16x8 : t
-
 val max_u_vec_i16x8 : t
-
 val avgr_u_vec_i16x8 : t
-
 val abs_vec_i32x4 : t
-
 val neg_vec_i32x4 : t
-
 val all_true_vec_i32x4 : t
-
 val bitmask_vec_i32x4 : t
-
 val shl_vec_i32x4 : t
-
 val shr_s_vec_i32x4 : t
-
 val shr_u_vec_i32x4 : t
-
 val add_vec_i32x4 : t
-
 val sub_vec_i32x4 : t
-
 val mul_vec_i32x4 : t
-
 val min_s_vec_i32x4 : t
-
 val min_u_vec_i32x4 : t
-
 val max_s_vec_i32x4 : t
-
 val max_u_vec_i32x4 : t
-
 val dot_s_vec_i16x8_to_vec_i32x4 : t
-
 val neg_vec_i64x2 : t
-
 val shl_vec_i64x2 : t
-
 val shr_s_vec_i64x2 : t
-
 val shr_u_vec_i64x2 : t
-
 val add_vec_i64x2 : t
-
 val sub_vec_i64x2 : t
-
 val mul_vec_i64x2 : t
-
 val abs_vec_f32x4 : t
-
 val neg_vec_f32x4 : t
-
 val sqrt_vec_f32x4 : t
-
 val add_vec_f32x4 : t
-
 val sub_vec_f32x4 : t
-
 val mul_vec_f32x4 : t
-
 val div_vec_f32x4 : t
-
 val min_vec_f32x4 : t
-
 val max_vec_f32x4 : t
-
 val p_min_vec_f32x4 : t
-
 val p_max_vec_f32x4 : t
-
 val ceil_vec_f32x4 : t
-
 val floor_vec_f32x4 : t
-
 val trunc_vec_f32x4 : t
-
 val nearest_vec_f32x4 : t
-
 val abs_vec_f64x2 : t
-
 val neg_vec_f64x2 : t
-
 val sqrt_vec_f64x2 : t
-
 val add_vec_f64x2 : t
-
 val sub_vec_f64x2 : t
-
 val mul_vec_f64x2 : t
-
 val div_vec_f64x2 : t
-
 val min_vec_f64x2 : t
-
 val max_vec_f64x2 : t
-
 val p_min_vec_f64x2 : t
-
 val p_max_vec_f64x2 : t
-
 val ceil_vec_f64x2 : t
-
 val floor_vec_f64x2 : t
-
 val trunc_vec_f64x2 : t
-
 val nearest_vec_f64x2 : t
-
 val trunc_sat_s_vec_f32x4_to_vec_i32x4 : t
-
 val trunc_sat_u_vec_f32x4_to_vec_i32x4 : t
-
 val convert_s_vec_i32x4_to_vec_f32x4 : t
-
 val convert_u_vec_i32x4_to_vec_f32x4 : t
-
 val narrow_s_vec_i16x8_to_vec_i8x16 : t
-
 val narrow_u_vec_i16x8_to_vec_i8x16 : t
-
 val narrow_s_vec_i32x4_to_vec_i16x8 : t
-
 val narrow_u_vec_i32x4_to_vec_i16x8 : t
-
 val swizzle_vec8x16 : t
-
 val ref_is_null : t
-
 val ref_is_func : t
-
 val ref_is_data : t
-
 val ref_is_i31 : t
-
 val ref_as_non_null : t
-
 val ref_as_func : t
-
 val ref_as_data : t
-
 val ref_as_i31 : t

--- a/virtual/settings.mli
+++ b/virtual/settings.mli
@@ -1,35 +1,18 @@
 val get_optimize_level : unit -> int
-
 val set_optimize_level : int -> unit
-
 val get_shrink_level : unit -> int
-
 val set_shrink_level : int -> unit
-
 val get_debug_info : unit -> bool
-
 val set_debug_info : bool -> unit
-
 val get_low_memory_unused : unit -> bool
-
 val set_low_memory_unused : bool -> unit
-
 val get_pass_argument : string -> string
-
 val set_pass_argument : string -> string -> unit
-
 val get_always_inline_max_size : unit -> int
-
 val set_always_inline_max_size : int -> unit
-
 val get_flexible_inline_max_size : unit -> int
-
 val set_flexible_inline_max_size : int -> unit
-
 val get_one_caller_inline_max_size : unit -> int
-
 val set_one_caller_inline_max_size : int -> unit
-
 val set_colors_enabled : bool -> unit
-
 val are_colors_enabled : unit -> bool

--- a/virtual/table.mli
+++ b/virtual/table.mli
@@ -11,9 +11,6 @@ val add_active_element_segment :
   Element_segment.t
 
 val remove_element_segment : Module.t -> string -> unit
-
 val get_num_element_segments : Module.t -> int
-
 val get_element_segment : Module.t -> string -> Element_segment.t
-
 val get_element_segment_by_index : Module.t -> int -> Element_segment.t

--- a/virtual/type.mli
+++ b/virtual/type.mli
@@ -1,25 +1,14 @@
 type t
 
 val none : t
-
 val int32 : t
-
 val int64 : t
-
 val float32 : t
-
 val float64 : t
-
 val vec128 : t
-
 val funcref : t
-
 val externref : t
-
 val unreachable : t
-
 val auto : t
-
 val create : t array -> t
-
 val expand : t -> t array


### PR DESCRIPTION
This upgrades binaryen.ml bindings to libbinaryen v103. I also added the new functions from the release and found a few other APIs that we didn't have.

Additionally, you'll noticed that the `module.exports` stuff is gone because I built binaryen.js without node as a target. In this version, it just attaches things onto the global `binaryen` object.

I tried writing some tests based on the kitchen sink additions in binaryen, but maybe @ospencer has some better test ideas.

Also snuck a formatting in here because my files kept changing.