### PR TITLE
feat!: Update libbinaryen to 107

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -16,5 +16,5 @@ depends: [
   "dune" {>= "2.9.1" < "3.0.0"}
   "dune-configurator" {>= "2.9.1" < "3.0.0"}
   "js_of_ocaml-compiler" {>= "3.10.0" < "4.0.0"}
-  "libbinaryen" {>= "106.0.0" < "107.0.0"}
+  "libbinaryen" {>= "107.0.0" < "108.0.0"}
 ]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fcb59ca5a849b1079497c0037155a8b8",
+  "checksum": "b457058cff75c1d285583590fc14c29b",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@4.13.1000@d41d8cd9": {
@@ -1238,14 +1238,14 @@
       ],
       "devDependencies": [ "ocaml@4.13.1000@d41d8cd9" ]
     },
-    "@grain/libbinaryen@106.0.0@d41d8cd9": {
-      "id": "@grain/libbinaryen@106.0.0@d41d8cd9",
+    "@grain/libbinaryen@107.0.0@d41d8cd9": {
+      "id": "@grain/libbinaryen@107.0.0@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "106.0.0",
+      "version": "107.0.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-106.0.0.tgz#sha1:268a76d0b798fc06cfe4236ccc553bdf19444c32"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-107.0.0.tgz#sha1:f6325f0b6ae301a3603d56c8d2414b56ec596e80"
         ]
       },
       "overrides": [],
@@ -1272,7 +1272,7 @@
         "ocaml@4.13.1000@d41d8cd9",
         "@opam/dune-configurator@opam:2.9.3@174e411b",
         "@opam/dune@opam:2.9.3@f57a6d69",
-        "@grain/libbinaryen@106.0.0@d41d8cd9"
+        "@grain/libbinaryen@107.0.0@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.20.1@30a05b69",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "ocaml": ">= 4.12.0 < 4.14.0",
-    "@grain/libbinaryen": ">= 106.0.0 < 107.0.0",
+    "@grain/libbinaryen": ">= 107.0.0 < 108.0.0",
     "@opam/dune": ">= 2.9.1 < 3.0.0",
     "@opam/dune-configurator": ">= 2.9.1 < 3.0.0"
   },

--- a/src/binaryen_stubs_features.c
+++ b/src/binaryen_stubs_features.c
@@ -114,6 +114,12 @@ caml_binaryen_feature_relaxed_simd(value unit) {
 }
 
 CAMLprim value
+caml_binaryen_feature_extended_const(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureExtendedConst()));
+}
+
+CAMLprim value
 caml_binaryen_feature_all(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_int(BinaryenFeatureAll()));

--- a/src/binaryen_stubs_features.js
+++ b/src/binaryen_stubs_features.js
@@ -98,6 +98,12 @@ function caml_binaryen_feature_relaxed_simd() {
   return binaryen.Features.RelaxedSIMD;
 }
 
+//Provides: caml_binaryen_feature_extended_const
+//Requires: binaryen
+function caml_binaryen_feature_extended_const() {
+  return binaryen.Features.ExtendedConst;
+}
+
 //Provides: caml_binaryen_feature_all
 //Requires: binaryen
 function caml_binaryen_feature_all() {

--- a/src/binaryen_stubs_ops.c
+++ b/src/binaryen_stubs_ops.c
@@ -2167,7 +2167,7 @@ caml_binaryen_binaryen_narrow_u_vec_i32x4_to_vec_i16x8(value unit) {
 CAMLprim value
 caml_binaryen_binaryen_swizzle_vec8x16(value unit) {
   CAMLparam1(unit);
-  BinaryenOp op = BinaryenSwizzleVec8x16();
+  BinaryenOp op = BinaryenSwizzleVecI8x16();
   CAMLreturn(alloc_BinaryenOp(op));
 }
 

--- a/src/binaryen_stubs_ops.js
+++ b/src/binaryen_stubs_ops.js
@@ -1843,7 +1843,7 @@ function caml_binaryen_binaryen_narrow_u_vec_i32x4_to_vec_i16x8() {
 //Provides: caml_binaryen_binaryen_swizzle_vec8x16
 //Requires: binaryen
 function caml_binaryen_binaryen_swizzle_vec8x16() {
-  return binaryen.Operations.SwizzleVec8x16;
+  return binaryen.Operations.SwizzleVecI8x16;
 }
 
 //Provides: caml_binaryen_binaryen_ref_is_null

--- a/src/module.ml
+++ b/src/module.ml
@@ -69,6 +69,10 @@ module Feature = struct
 
   let relaxed_simd = relaxed_simd ()
 
+  external extended_const : unit -> t = "caml_binaryen_feature_extended_const"
+
+  let extended_const = extended_const ()
+
   external all : unit -> t = "caml_binaryen_feature_all"
 
   let all = all ()

--- a/src/module.mli
+++ b/src/module.mli
@@ -18,6 +18,7 @@ module Feature : sig
   val memory64 : t
   val typed_function_references : t
   val relaxed_simd : t
+  val extended_const : t
   val all : t
 end
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -197,6 +197,7 @@ let _ =
       Module.Feature.memory64;
       Module.Feature.typed_function_references;
       Module.Feature.relaxed_simd;
+      Module.Feature.extended_const;
       Module.Feature.all;
     ]
 


### PR DESCRIPTION
I believe this is everything we need for Binaryen version_107. There were some other changes related to SIMD but we don't support that yet.

@ospencer can you review https://github.com/WebAssembly/binaryen/compare/version_106...version_107 to make sure I got everything changed/new?