### PR TITLE
feat: Add signature_pruning pass

### DIFF
--- a/src/passes.ml
+++ b/src/passes.ml
@@ -275,6 +275,9 @@ let safe_heap = "safe-heap"
 (** sets specified globals to specified values *)
 let set_globals = "set-globals"
 
+(** remove params from function signature types where possible *)
+let signature_pruning = "signature-pruning"
+
 (** apply more specific subtypes to signature types where possible *)
 let signature_refining = "signature-refining"
 

--- a/src/passes.mli
+++ b/src/passes.mli
@@ -273,6 +273,9 @@ val safe_heap : t
 val set_globals : t
 (** sets specified globals to specified values *)
 
+val signature_pruning : t
+(** remove params from function signature types where possible *)
+
 val signature_refining : t
 (** apply more specific subtypes to signature types where possible *)
 


### PR DESCRIPTION
This is only run during the default passes if the module has GC enabled, so not a big deal, but we should have it for completion.