### PR TITLE
fix: Convert JSOO lists to JS arrays before working with them

### DIFF
--- a/src/binaryen_stubs_memory.js
+++ b/src/binaryen_stubs_memory.js
@@ -2,11 +2,13 @@
 //Requires: caml_list_to_js_array, caml_convert_bytes_to_array
 //Requires: caml_jsstring_of_string, caml_js_from_bool
 function caml_binaryen_set_memory(wasm_mod, initial, maximum, exportName, segments, segmentPassives, segmentOffsets, segmentSizes, shared) {
+  var passives = caml_list_to_js_array(segmentPassives);
+  var offsets = caml_list_to_js_array(segmentOffsets);
   var segs = caml_list_to_js_array(segments).map(function (segment, idx) {
     return {
       data: caml_convert_bytes_to_array(segment),
-      passive: caml_js_from_bool(segmentPassives[idx + 1]), // OCaml Lists are offset by 1
-      offset: segmentOffsets[idx + 1] // OCaml Lists are offset by 1
+      passive: caml_js_from_bool(passives[idx]),
+      offset: offsets[idx]
     }
   });
 


### PR DESCRIPTION
While debugging an issue that @ospencer was having, I found that my "off-by-one" list assumption was incorrect and JSOO lists are more complex. We need to convert the lists to JS arrays before working with them to do this correctly.