### PR TITLE
feat: Add eqref, i31ref, and dataref types

### DIFF
--- a/src/binaryen_stubs_types.c
+++ b/src/binaryen_stubs_types.c
@@ -73,6 +73,27 @@ caml_binaryen_type_externref(value unit) {
 }
 
 CAMLprim value
+caml_binaryen_type_eqref(value unit) {
+  CAMLparam1(unit);
+  BinaryenType ty = BinaryenTypeEqref();
+  CAMLreturn(alloc_BinaryenType(ty));
+}
+
+CAMLprim value
+caml_binaryen_type_i31ref(value unit) {
+  CAMLparam1(unit);
+  BinaryenType ty = BinaryenTypeI31ref();
+  CAMLreturn(alloc_BinaryenType(ty));
+}
+
+CAMLprim value
+caml_binaryen_type_dataref(value unit) {
+  CAMLparam1(unit);
+  BinaryenType ty = BinaryenTypeDataref();
+  CAMLreturn(alloc_BinaryenType(ty));
+}
+
+CAMLprim value
 caml_binaryen_type_unreachable(value unit) {
   CAMLparam1(unit);
   BinaryenType ty = BinaryenTypeUnreachable();

--- a/src/binaryen_stubs_types.js
+++ b/src/binaryen_stubs_types.js
@@ -46,6 +46,24 @@ function caml_binaryen_type_externref() {
   return binaryen.externref;
 }
 
+//Provides: caml_binaryen_type_eqref
+//Requires: binaryen
+function caml_binaryen_type_eqref() {
+  return binaryen.eqref;
+}
+
+//Provides: caml_binaryen_type_i31ref
+//Requires: binaryen
+function caml_binaryen_type_i31ref() {
+  return binaryen.i31ref;
+}
+
+//Provides: caml_binaryen_type_dataref
+//Requires: binaryen
+function caml_binaryen_type_dataref() {
+  return binaryen.dataref;
+}
+
 //Provides: caml_binaryen_type_unreachable
 //Requires: binaryen
 function caml_binaryen_type_unreachable() {

--- a/src/type.ml
+++ b/src/type.ml
@@ -32,6 +32,18 @@ external externref : unit -> t = "caml_binaryen_type_externref"
 
 let externref = externref ()
 
+external eqref : unit -> t = "caml_binaryen_type_eqref"
+
+let eqref = eqref ()
+
+external i31ref : unit -> t = "caml_binaryen_type_i31ref"
+
+let i31ref = i31ref ()
+
+external dataref : unit -> t = "caml_binaryen_type_dataref"
+
+let dataref = dataref ()
+
 external unreachable : unit -> t = "caml_binaryen_type_unreachable"
 
 let unreachable = unreachable ()

--- a/src/type.mli
+++ b/src/type.mli
@@ -8,6 +8,9 @@ val float64 : t
 val vec128 : t
 val funcref : t
 val externref : t
+val eqref : t
+val i31ref : t
+val dataref : t
 val unreachable : t
 val auto : t
 val create : t array -> t


### PR DESCRIPTION
While digging into v108 of binaryen for the changes to externref (switched to anyref), I noticed that we didn't have these 3 reference types.

@ospencer what would it take to test these in our setup?