### PR TITLE
fix!: Properly accept the size argument to Memory_init.make

### DIFF
--- a/src/expression.ml
+++ b/src/expression.ml
@@ -708,7 +708,8 @@ module Memory_grow = struct
 end
 
 module Memory_init = struct
-  external make : Module.t -> int -> t -> t -> t = "caml_binaryen_memory_init"
+  external make : Module.t -> int -> t -> t -> t -> t
+    = "caml_binaryen_memory_init"
   (** Module, segment, destination, offset, size. *)
 
   external get_segment : t -> int = "caml_binaryen_memory_init_get_segment"

--- a/src/expression.mli
+++ b/src/expression.mli
@@ -256,7 +256,7 @@ module Memory_grow : sig
 end
 
 module Memory_init : sig
-  val make : Module.t -> int -> t -> t -> t
+  val make : Module.t -> int -> t -> t -> t -> t
   val get_segment : t -> int
   val set_segment : t -> int -> unit
   val get_dest : t -> t


### PR DESCRIPTION
While working on the v110 bindings, I noticed that this function didn't actually allow the correct number of arguments.