### PR TITLE
fix: Properly handle load & store instructions in JS

### DIFF
--- a/src/binaryen_stubs_expressions.js
+++ b/src/binaryen_stubs_expressions.js
@@ -189,11 +189,12 @@ function caml_binaryen_load(
 
   switch (typ) {
     case Binaryen.i32: {
-      if (signed) {
-        if (bytes === 4) {
-          return wasm_mod.i32.load(offset, align, ptr, name);
-        }
+      // Using four bytes doesn't matter if it is signed or unsigned
+      if (bytes === 4) {
+        return wasm_mod.i32.load(offset, align, ptr, name);
+      }
 
+      if (signed) {
         if (bytes === 1) {
           return wasm_mod.i32.load8_s(offset, align, ptr, name);
         }
@@ -210,13 +211,16 @@ function caml_binaryen_load(
           return wasm_mod.i32.load16_u(offset, align, ptr, name);
         }
       }
+
+      break;
     }
     case Binaryen.i64: {
-      if (signed) {
-        if (bytes === 8) {
-          return wasm_mod.i64.load(offset, align, ptr, name);
-        }
+      // Using eight bytes doesn't matter if it is signed or unsigned
+      if (bytes === 8) {
+        return wasm_mod.i64.load(offset, align, ptr, name);
+      }
 
+      if (signed) {
         if (bytes === 1) {
           return wasm_mod.i64.load8_s(offset, align, ptr, name);
         }
@@ -241,6 +245,8 @@ function caml_binaryen_load(
           return wasm_mod.i64.load32_u(offset, align, ptr, name);
         }
       }
+
+      break;
     }
     case Binaryen.f32: {
       return wasm_mod.f32.load(offset, align, ptr, name);
@@ -300,6 +306,8 @@ function caml_binaryen_store(
       if (bytes === 2) {
         return wasm_mod.i32.store16(offset, align, ptr, value, name);
       }
+
+      break;
     }
     case Binaryen.i64: {
       if (bytes === 8) {
@@ -317,6 +325,8 @@ function caml_binaryen_store(
       if (bytes === 4) {
         return wasm_mod.i64.store32(offset, align, ptr, value, name);
       }
+
+      break;
     }
     case Binaryen.f32: {
       return wasm_mod.f32.store(offset, align, ptr, value, name);

--- a/test/test.expected
+++ b/test/test.expected
@@ -33,7 +33,7 @@
    (i32.add
     (select
      (local.get $0)
-     (i32.load8_s
+     (i32.load
       (local.get $1)
      )
      (i32.const 1)
@@ -85,7 +85,7 @@
   (i32.add
    (select
     (local.get $0)
-    (i32.load8_s
+    (i32.load
      (local.get $1)
     )
     (i32.const 1)
@@ -133,7 +133,7 @@
   (i32.add
    (select
     (local.get $0)
-    (i32.load8_s
+    (i32.load
      (local.get $1)
     )
     (i32.const 1)
@@ -180,7 +180,7 @@
  (func $0 (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
-  i32.load8_s $0
+  i32.load $0
   i32.const 1
   select
   local.get $1

--- a/test/test.ml
+++ b/test/test.ml
@@ -58,7 +58,7 @@ let x () = Expression.Local_get.make wasm_mod 0 Type.int32
 let y () = Expression.Local_get.make wasm_mod 1 Type.int32
 
 let load =
-  Expression.Load.make wasm_mod 1 ~signed:true 0 0 Type.int32 (y ()) "0"
+  Expression.Load.make wasm_mod 4 ~signed:false 0 0 Type.int32 (y ()) "0"
 
 let select =
   Expression.Select.make wasm_mod
@@ -204,6 +204,7 @@ let _ =
        Type.int32)
 
 let _ = Export.add_function_export wasm_mod "hello" "hello"
+let _ = Module.validate wasm_mod
 
 (* Shouldn't actually do anything since we aren't doing function renames *)
 let _ = Module.update_maps wasm_mod


### PR DESCRIPTION
This is super broken. Here are the fixes.

I blame @ospencer for having me change to a `switch` and blame myself for forgetting how `switch` works in JS.