### PR TITLE
chore: Ensure non-breaking features are released as patch before 1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
           package-name: binaryen.ml
           pull-request-title-pattern: "chore${scope}: Release${component} ${version}"
           bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true
 
   add-archive:
     needs: [release-please]


### PR DESCRIPTION
We could bump to 0.21.0 but it feels better to become `0.20.1`. What do you think @ospencer?