### PR TITLE
chore(ci): Restrict esy to 0.6 until our cmake supports 0.7

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -29,7 +29,7 @@ jobs:
       # It also adds `shx` globally for cross-platform shell commands
       - name: Setup environment
         run: |
-          npm i -g esy
+          npm i -g esy@0.6.14
           npm i -g shx
 
       - name: Checkout project


### PR DESCRIPTION
Our CI is failing on Windows because esy 0.7 fails to build our pretty old version of cmake. I have a new version in the works but that'll be included in libbinaryen 113 so I'm just restricting esy in our CI for this release.