### PR TITLE
chore(admin): Update actions dependencies

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       - name: Setup node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4.3.0
         with:
-          node-version: "16"
+          node-version: "22"
           check-latest: true
 
       # Install `esy` to build the project
@@ -33,7 +33,7 @@ jobs:
           npm i -g shx
 
       - name: Checkout project
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.2.2
         with:
           submodules: "recursive"
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Esy cache
         id: esy-cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4.2.3
         with:
           path: _export
           key: ${{ runner.os }}-esy-${{ hashFiles('esy.lock/index.json') }}

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.2.2
         with:
           submodules: "recursive"
 
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         if: ${{ startsWith(matrix.os, 'windows-') }}
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
@@ -35,7 +35,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
 
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         if: ${{ !startsWith(matrix.os, 'windows-') }}
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           brew install git-archive-all
 
       - name: Checkout code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.2.2
         with:
           submodules: "recursive"
 
@@ -84,7 +84,7 @@ jobs:
           echo -n "$CHANGES" > CHANGES.md
 
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.14.0
 
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4.3.0
         with:
-          node-version: "16"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm


### PR DESCRIPTION
I noticed our ci workflows were failing because the backend for `actions/cache` changed deprecating versions pre `v3.4.0`. This pr updates that along with some of other dependencies. 


I switched the node version were using from `v16` to lts as well (happy to revert this if we don't like the change. but Im pretty sure it doesn't matter too much given were just using it for esy).