### PR TITLE
feat!: Upgrade to Binaryen v124

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -16,6 +16,6 @@ depends: [
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.0.0" < "7.0.0"}
-  "libbinaryen" {>= "123.0.1" < "124.0.0"}
+  "libbinaryen" {>= "124.0.1" < "125.0.0"}
 ]
 x-maintenance-intent: ["0.(latest)"]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "155674e15af22e7cb1432c6d5b252eee",
+  "checksum": "43b607828957b76c0263dc0b329d0237",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {
@@ -1960,14 +1960,14 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@grain/libbinaryen@123.0.1@d41d8cd9": {
-      "id": "@grain/libbinaryen@123.0.1@d41d8cd9",
+    "@grain/libbinaryen@124.0.1@d41d8cd9": {
+      "id": "@grain/libbinaryen@124.0.1@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "123.0.1",
+      "version": "124.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-123.0.1.tgz#sha1:5d4c992f6761d67d7d297bb48f0f4093ab5328e4"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-124.0.1.tgz#sha1:7b29acc4a62ab5a849c6e01c3d8e90c78efd05f2"
         ]
       },
       "overrides": [],
@@ -1999,7 +1999,7 @@
         "ocaml@5.3.0@d41d8cd9",
         "@opam/dune-configurator@opam:3.20.2@7eb6ff01",
         "@opam/dune@opam:3.20.2@8daef28d",
-        "@grain/libbinaryen@123.0.1@d41d8cd9"
+        "@grain/libbinaryen@124.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.27.0@c40d4612",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "ocaml": ">= 4.13.0 < 5.4.0",
-    "@grain/libbinaryen": ">= 123.0.0 < 124.0.0",
+    "@grain/libbinaryen": ">= 124.0.0 < 125.0.0",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"
   },

--- a/src/function.c
+++ b/src/function.c
@@ -74,6 +74,14 @@ caml_binaryen_set_start(value _module, value _fun) {
 }
 
 CAMLprim value
+caml_binaryen_get_start(value _module) {
+  CAMLparam1(_module);
+  BinaryenModuleRef module = BinaryenModuleRef_val(_module);
+  BinaryenFunctionRef fun = BinaryenGetStart(module);
+  CAMLreturn(alloc_BinaryenFunctionRef(fun));
+}
+
+CAMLprim value
 caml_binaryen_function_set_debug_location(value _fun, value _exp, value _file, value _line, value _column) {
   CAMLparam5(_fun, _exp, _file, _line, _column);
   BinaryenFunctionRef fun = BinaryenFunctionRef_val(_fun);

--- a/src/function.js
+++ b/src/function.js
@@ -56,6 +56,11 @@ function caml_binaryen_set_start(wasm_mod, func) {
   return wasm_mod.setStart(func);
 }
 
+//Provides: caml_binaryen_get_start
+function caml_binaryen_get_start(wasm_mod) {
+  return wasm_mod.getStart();
+}
+
 //Provides: caml_binaryen_function_set_debug_location
 //Requires: Binaryen
 function caml_binaryen_function_set_debug_location(

--- a/src/function.ml
+++ b/src/function.ml
@@ -6,6 +6,7 @@ external add_function :
 (** Module, name, params type, results type, locals types, body. *)
 
 external set_start : Module.t -> t -> unit = "caml_binaryen_set_start"
+external get_start : Module.t -> t = "caml_binaryen_get_start"
 
 external set_debug_location : t -> Expression.t -> int -> int -> int -> unit
   = "caml_binaryen_function_set_debug_location"

--- a/src/function.mli
+++ b/src/function.mli
@@ -4,6 +4,7 @@ val add_function :
   Module.t -> string -> Type.t -> Type.t -> Type.t array -> Expression.t -> t
 
 val set_start : Module.t -> t -> unit
+val get_start : Module.t -> t
 val set_debug_location : t -> Expression.t -> int -> int -> int -> unit
 val get_function : Module.t -> string -> t
 val get_function_by_index : Module.t -> int -> t

--- a/test/test.ml
+++ b/test/test.ml
@@ -170,12 +170,14 @@ let start =
 
 let _ = Export.add_function_export wasm_mod "adder" "adder"
 let _ = Table.add_table wasm_mod "table" 1 1 Type.funcref
-let funcref_expr1 = Expression.Ref.func wasm_mod "adder" (Heap_type.func ())
+
+(* TODO(#240): Re-enable after type-builder api is merged *)
+(* let funcref_expr1 = Expression.Ref.func wasm_mod "adder" (Heap_type.func ())
 
 let _ =
   Expression.Table.set wasm_mod "table"
     (Expression.Const.make wasm_mod (Literal.int32 0l))
-    funcref_expr1
+    funcref_expr1 *)
 
 let funcref_expr2 =
   Expression.Table.get wasm_mod "table"
@@ -212,6 +214,8 @@ let _ =
     (Expression.Const.make wasm_mod (Literal.int32 0l))
 
 let _ = Function.set_start wasm_mod start
+let start_func = Function.get_start wasm_mod
+let _ = assert (Function.get_name start_func = "start")
 
 let segment : Binaryen.Memory.segment =
   let data = Bytes.of_string "hello" in


### PR DESCRIPTION
Full Diff: https://github.com/WebAssembly/binaryen/compare/version_123...version_124

Note: Before this can be merged we need to release libbinaryen v124, and switch the esy package over to the released version.
Note: Because I did this from my fork until 123 is merged this diffs with main rather than 123, better to just view the diff for the final commit.