### PR TITLE
fix!: Correct signature of `get_pass_argument`

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -72,7 +72,11 @@ caml_binaryen_get_pass_argument(value _name) {
   CAMLparam1(_name);
   const char* name = Safe_String_val(_name);
   const char* val = BinaryenGetPassArgument(name);
-  CAMLreturn(caml_copy_string(val));
+  if (val == NULL) {
+    CAMLreturn(Val_none);
+  } else {
+    CAMLreturn(caml_alloc_some(caml_copy_string(val)));
+  }
 }
 
 CAMLprim value

--- a/src/settings.js
+++ b/src/settings.js
@@ -53,8 +53,11 @@ function caml_binaryen_set_low_memory_unused(on) {
 //Provides: caml_binaryen_get_pass_argument
 //Requires: Binaryen
 //Requires: caml_jsstring_of_string
+//Requires: to_option
 function caml_binaryen_get_pass_argument(name) {
-  return Binaryen.getPassArgument(caml_jsstring_of_string(name));
+  var val = Binaryen.getPassArgument(caml_jsstring_of_string(name));
+  var str = name != null ? val : null;
+  return to_option(str);
 }
 
 //Provides: caml_binaryen_set_pass_argument

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -11,7 +11,7 @@ external get_low_memory_unused : unit -> bool
 external set_low_memory_unused : bool -> unit
   = "caml_binaryen_set_low_memory_unused"
 
-external get_pass_argument : string -> string
+external get_pass_argument : string -> string option
   = "caml_binaryen_get_pass_argument"
 
 external set_pass_argument : string -> string -> unit

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -6,7 +6,7 @@ val get_debug_info : unit -> bool
 val set_debug_info : bool -> unit
 val get_low_memory_unused : unit -> bool
 val set_low_memory_unused : bool -> unit
-val get_pass_argument : string -> string
+val get_pass_argument : string -> string option
 val set_pass_argument : string -> string -> unit
 val get_always_inline_max_size : unit -> int
 val set_always_inline_max_size : int -> unit

--- a/test/test.ml
+++ b/test/test.ml
@@ -21,6 +21,13 @@ let wasm_mod = Module.create ()
 let _ = Module.set_features wasm_mod [ Module.Feature.all ]
 let import_wasm_mod = Module.create ()
 
+(* Testing pass_argument *)
+let _ = assert (Settings.get_pass_argument "theKey" = None)
+let _ = Settings.set_pass_argument "theKey" "theValue"
+let _ = assert (Settings.get_pass_argument "theKey" = Some "theValue")
+let _ = Settings.set_pass_argument "theKey" "theValue2"
+let _ = assert (Settings.get_pass_argument "theKey" = Some "theValue2")
+
 let _ =
   Import.add_memory_import import_wasm_mod "internal_name" "external_name"
     "external_base_name" true


### PR DESCRIPTION
This is breaking as we are changing the api signature.

Previously, we segfaulted on the `NULL` return case.


Closes: #246 