### PR TITLE
chore: Run CI only on pull_request and pushes to main

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -1,7 +1,8 @@
 name: Esy
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -1,7 +1,8 @@
 name: Opam
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
@@ -24,7 +25,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: "recursive"
-      
+
       - name: Setup node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:


### PR DESCRIPTION
This matches what we do in the main Grain repository.