### PR TITLE
feat!: Upgrade to Binaryen v123

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -16,6 +16,6 @@ depends: [
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.0.0" < "7.0.0"}
-  "libbinaryen" {>= "122.0.1" < "123.0.0"}
+  "libbinaryen" {>= "123.0.1" < "124.0.0"}
 ]
 x-maintenance-intent: ["0.(latest)"]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "55b439676e74c57977482d2499504bd2",
+  "checksum": "155674e15af22e7cb1432c6d5b252eee",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {
@@ -102,7 +102,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.0@fa72996d",
+        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.1@2377d2f8",
         "@opam/ocamlfind@opam:1.9.8@ee910ff5",
         "@opam/ocamlbuild@opam:0.16.1@b3fc8209",
         "@opam/cmdliner@opam:1.3.0@8e6dd99f",
@@ -135,7 +135,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@5.3.0@d41d8cd9", "@opam/uutf@opam:1.0.4@ba7fbef7",
-        "@opam/uucp@opam:17.0.0@843de755", "@opam/topkg@opam:1.1.0@fa72996d",
+        "@opam/uucp@opam:17.0.0@843de755", "@opam/topkg@opam:1.1.1@2377d2f8",
         "@opam/ocamlfind@opam:1.9.8@ee910ff5",
         "@opam/ocamlbuild@opam:0.16.1@b3fc8209",
         "@opam/cmdliner@opam:1.3.0@8e6dd99f",
@@ -169,7 +169,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.0@fa72996d",
+        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.1@2377d2f8",
         "@opam/ocamlfind@opam:1.9.8@ee910ff5",
         "@opam/ocamlbuild@opam:0.16.1@b3fc8209",
         "@opam/cmdliner@opam:1.3.0@8e6dd99f",
@@ -183,20 +183,20 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@opam/topkg@opam:1.1.0@fa72996d": {
-      "id": "@opam/topkg@opam:1.1.0@fa72996d",
+    "@opam/topkg@opam:1.1.1@2377d2f8": {
+      "id": "@opam/topkg@opam:1.1.1@2377d2f8",
       "name": "@opam/topkg",
-      "version": "opam:1.1.0",
+      "version": "opam:1.1.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha512/34/34d22ae5b6bd166dd4a601a7d12d89c336684b3c56d7c7f481b40837eab263616cc3a6e6f63602f3d4a7d53c911967bf261de6c1ac205341b98a9838e5ea7aeb#sha512:34d22ae5b6bd166dd4a601a7d12d89c336684b3c56d7c7f481b40837eab263616cc3a6e6f63602f3d4a7d53c911967bf261de6c1ac205341b98a9838e5ea7aeb",
-          "archive:https://erratique.ch/software/topkg/releases/topkg-1.1.0.tbz#sha512:34d22ae5b6bd166dd4a601a7d12d89c336684b3c56d7c7f481b40837eab263616cc3a6e6f63602f3d4a7d53c911967bf261de6c1ac205341b98a9838e5ea7aeb"
+          "archive:https://opam.ocaml.org/cache/sha512/c3/c36c549a362ddf5b7fe3f6ff91c79b7ab531c43633bb9737576370bcbd69db7e1625d247c278a869b503d45a175e9753231ccf595e5bfa4e3b7e2602ac3d3b42#sha512:c36c549a362ddf5b7fe3f6ff91c79b7ab531c43633bb9737576370bcbd69db7e1625d247c278a869b503d45a175e9753231ccf595e5bfa4e3b7e2602ac3d3b42",
+          "archive:https://erratique.ch/software/topkg/releases/topkg-1.1.1.tbz#sha512:c36c549a362ddf5b7fe3f6ff91c79b7ab531c43633bb9737576370bcbd69db7e1625d247c278a869b503d45a175e9753231ccf595e5bfa4e3b7e2602ac3d3b42"
         ],
         "opam": {
           "name": "topkg",
-          "version": "1.1.0",
-          "path": "esy.lock/opam/topkg.1.1.0"
+          "version": "1.1.1",
+          "path": "esy.lock/opam/topkg.1.1.1"
         }
       },
       "overrides": [],
@@ -1394,7 +1394,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.0@fa72996d",
+        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.1@2377d2f8",
         "@opam/ocamlfind@opam:1.9.8@ee910ff5",
         "@opam/ocamlbuild@opam:0.16.1@b3fc8209",
         "@opam/astring@opam:0.8.5@9975798d",
@@ -1947,7 +1947,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.0@fa72996d",
+        "ocaml@5.3.0@d41d8cd9", "@opam/topkg@opam:1.1.1@2377d2f8",
         "@opam/ocamlfind@opam:1.9.8@ee910ff5",
         "@opam/ocamlbuild@opam:0.16.1@b3fc8209",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1960,14 +1960,14 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@grain/libbinaryen@122.0.0@d41d8cd9": {
-      "id": "@grain/libbinaryen@122.0.0@d41d8cd9",
+    "@grain/libbinaryen@123.0.1@d41d8cd9": {
+      "id": "@grain/libbinaryen@123.0.1@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "122.0.0",
+      "version": "123.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-122.0.0.tgz#sha1:63c01c799e798e88fbf86c60a5b4b151c062e635"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-123.0.1.tgz#sha1:5d4c992f6761d67d7d297bb48f0f4093ab5328e4"
         ]
       },
       "overrides": [],
@@ -1999,7 +1999,7 @@
         "ocaml@5.3.0@d41d8cd9",
         "@opam/dune-configurator@opam:3.20.2@7eb6ff01",
         "@opam/dune@opam:3.20.2@8daef28d",
-        "@grain/libbinaryen@122.0.0@d41d8cd9"
+        "@grain/libbinaryen@123.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.27.0@c40d4612",

--- a/esy.lock/opam/topkg.1.1.1/opam
+++ b/esy.lock/opam/topkg.1.1.1/opam
@@ -43,8 +43,8 @@ depends: [
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{dev}%"]
 dev-repo: "git+https://erratique.ch/repos/topkg.git"
 url {
-  src: "https://erratique.ch/software/topkg/releases/topkg-1.1.0.tbz"
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.1.1.tbz"
   checksum:
-    "sha512=34d22ae5b6bd166dd4a601a7d12d89c336684b3c56d7c7f481b40837eab263616cc3a6e6f63602f3d4a7d53c911967bf261de6c1ac205341b98a9838e5ea7aeb"
+    "sha512=c36c549a362ddf5b7fe3f6ff91c79b7ab531c43633bb9737576370bcbd69db7e1625d247c278a869b503d45a175e9753231ccf595e5bfa4e3b7e2602ac3d3b42"
 }
 x-maintenance-intent: ["(latest)"]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "ocaml": ">= 4.13.0 < 5.4.0",
-    "@grain/libbinaryen": ">= 122.0.0 < 123.0.0",
+    "@grain/libbinaryen": ">= 123.0.0 < 124.0.0",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"
   },

--- a/src/expression.c
+++ b/src/expression.c
@@ -1868,7 +1868,7 @@ caml_binaryen_ref_func(value _module, value _name, value _ty) {
   CAMLparam3(_module, _name, _ty);
   BinaryenModuleRef module = BinaryenModuleRef_val(_module);
   char* name = Safe_String_val(_name);
-  BinaryenType ty = BinaryenType_val(_ty);
+  BinaryenHeapType ty = BinaryenHeapType_val(_ty);
   BinaryenExpressionRef exp = BinaryenRefFunc(module, name, ty);
   CAMLreturn(alloc_BinaryenExpressionRef(exp));
 }

--- a/src/expression.ml
+++ b/src/expression.ml
@@ -824,7 +824,8 @@ module Ref = struct
   external as_ : Module.t -> Op.t -> t -> t = "caml_binaryen_ref_as"
   (** Module, op, value *)
 
-  external func : Module.t -> string -> Type.t -> t = "caml_binaryen_ref_func"
+  external func : Module.t -> string -> Heap_type.t -> t
+    = "caml_binaryen_ref_func"
   (** Module, func, type *)
 
   external eq : Module.t -> t -> t -> t = "caml_binaryen_ref_eq"

--- a/src/expression.mli
+++ b/src/expression.mli
@@ -343,7 +343,7 @@ module Ref : sig
   val as_ : Module.t -> Op.t -> t -> t
   (** Module, op, value *)
 
-  val func : Module.t -> string -> Type.t -> t
+  val func : Module.t -> string -> Heap_type.t -> t
   (** Module, func, type *)
 
   val eq : Module.t -> t -> t -> t

--- a/src/module.ml
+++ b/src/module.ml
@@ -14,10 +14,6 @@ module Feature = struct
 
   let atomics = atomics ()
 
-  external bulk_memory : unit -> t = "caml_binaryen_feature_bulk_memory"
-
-  let bulk_memory = bulk_memory ()
-
   external mutable_globals : unit -> t = "caml_binaryen_feature_mutable_globals"
 
   let mutable_globals = mutable_globals ()
@@ -27,13 +23,17 @@ module Feature = struct
 
   let nontrapping_fp_to_int = nontrapping_fp_to_int ()
 
-  external sign_ext : unit -> t = "caml_binaryen_feature_sign_ext"
-
-  let sign_ext = sign_ext ()
-
   external simd128 : unit -> t = "caml_binaryen_feature_simd128"
 
   let simd128 = simd128 ()
+
+  external bulk_memory : unit -> t = "caml_binaryen_feature_bulk_memory"
+
+  let bulk_memory = bulk_memory ()
+
+  external sign_ext : unit -> t = "caml_binaryen_feature_sign_ext"
+
+  let sign_ext = sign_ext ()
 
   external exception_handling : unit -> t
     = "caml_binaryen_feature_exception_handling"
@@ -75,6 +75,28 @@ module Feature = struct
   external multi_memory : unit -> t = "caml_binaryen_feature_multi_memory"
 
   let multi_memory = multi_memory ()
+
+  external stack_switching : unit -> t = "caml_binaryen_feature_stack_switching"
+
+  let stack_switching = stack_switching ()
+
+  external shared_everything : unit -> t
+    = "caml_binaryen_feature_shared_everything"
+
+  let shared_everything = shared_everything ()
+
+  external fp16 : unit -> t = "caml_binaryen_feature_fp16"
+
+  let fp16 = fp16 ()
+
+  external bulk_memory_opt : unit -> t = "caml_binaryen_feature_bulk_memory_opt"
+
+  let bulk_memory_opt = bulk_memory_opt ()
+
+  external call_indirect_overlong : unit -> t
+    = "caml_binaryen_feature_call_indirect_overlong"
+
+  let call_indirect_overlong = call_indirect_overlong ()
 
   external all : unit -> t = "caml_binaryen_feature_all"
 

--- a/src/module.mli
+++ b/src/module.mli
@@ -5,11 +5,11 @@ module Feature : sig
 
   val mvp : t
   val atomics : t
-  val bulk_memory : t
   val mutable_globals : t
   val nontrapping_fp_to_int : t
-  val sign_ext : t
   val simd128 : t
+  val bulk_memory : t
+  val sign_ext : t
   val exception_handling : t
   val tail_call : t
   val reference_types : t
@@ -20,6 +20,11 @@ module Feature : sig
   val extended_const : t
   val strings : t
   val multi_memory : t
+  val stack_switching : t
+  val shared_everything : t
+  val fp16 : t
+  val bulk_memory_opt : t
+  val call_indirect_overlong : t
   val all : t
 end
 

--- a/src/module_feature.c
+++ b/src/module_feature.c
@@ -36,12 +36,6 @@ caml_binaryen_feature_atomics(value unit) {
 }
 
 CAMLprim value
-caml_binaryen_feature_bulk_memory(value unit) {
-  CAMLparam1(unit);
-  CAMLreturn(Val_int(BinaryenFeatureBulkMemory()));
-}
-
-CAMLprim value
 caml_binaryen_feature_mutable_globals(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_int(BinaryenFeatureMutableGlobals()));
@@ -54,15 +48,21 @@ caml_binaryen_feature_nontrapping_fp_to_int(value unit) {
 }
 
 CAMLprim value
-caml_binaryen_feature_sign_ext(value unit) {
-  CAMLparam1(unit);
-  CAMLreturn(Val_int(BinaryenFeatureSignExt()));
-}
-
-CAMLprim value
 caml_binaryen_feature_simd128(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_int(BinaryenFeatureSIMD128()));
+}
+
+CAMLprim value
+caml_binaryen_feature_bulk_memory(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureBulkMemory()));
+}
+
+CAMLprim value
+caml_binaryen_feature_sign_ext(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureSignExt()));
 }
 
 CAMLprim value
@@ -123,6 +123,36 @@ CAMLprim value
 caml_binaryen_feature_multi_memory(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_int(BinaryenFeatureMultiMemory()));
+}
+
+CAMLprim value
+caml_binaryen_feature_stack_switching(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureStackSwitching()));
+}
+
+CAMLprim value
+caml_binaryen_feature_shared_everything(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureSharedEverything()));
+}
+
+CAMLprim value
+caml_binaryen_feature_fp16(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureFP16()));
+}
+
+CAMLprim value
+caml_binaryen_feature_bulk_memory_opt(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureBulkMemoryOpt()));
+}
+
+CAMLprim value
+caml_binaryen_feature_call_indirect_overlong(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureCallIndirectOverlong()));
 }
 
 CAMLprim value

--- a/src/module_feature.js
+++ b/src/module_feature.js
@@ -20,12 +20,6 @@ function caml_binaryen_feature_atomics() {
   return Binaryen.Features.Atomics;
 }
 
-//Provides: caml_binaryen_feature_bulk_memory
-//Requires: Binaryen
-function caml_binaryen_feature_bulk_memory() {
-  return Binaryen.Features.BulkMemory;
-}
-
 //Provides: caml_binaryen_feature_mutable_globals
 //Requires: Binaryen
 function caml_binaryen_feature_mutable_globals() {
@@ -38,16 +32,22 @@ function caml_binaryen_feature_nontrapping_fp_to_int() {
   return Binaryen.Features.NontrappingFPToInt;
 }
 
-//Provides: caml_binaryen_feature_sign_ext
-//Requires: Binaryen
-function caml_binaryen_feature_sign_ext() {
-  return Binaryen.Features.SignExt;
-}
-
 //Provides: caml_binaryen_feature_simd128
 //Requires: Binaryen
 function caml_binaryen_feature_simd128() {
   return Binaryen.Features.SIMD128;
+}
+
+//Provides: caml_binaryen_feature_bulk_memory
+//Requires: Binaryen
+function caml_binaryen_feature_bulk_memory() {
+  return Binaryen.Features.BulkMemory;
+}
+
+//Provides: caml_binaryen_feature_sign_ext
+//Requires: Binaryen
+function caml_binaryen_feature_sign_ext() {
+  return Binaryen.Features.SignExt;
 }
 
 //Provides: caml_binaryen_feature_exception_handling
@@ -108,6 +108,36 @@ function caml_binaryen_feature_strings() {
 //Requires: Binaryen
 function caml_binaryen_feature_multi_memory() {
   return Binaryen.Features.MultiMemory;
+}
+
+//Provides: caml_binaryen_feature_stack_switching
+//Requires: Binaryen
+function caml_binaryen_feature_stack_switching() {
+  return Binaryen.Features.StackSwitching;
+}
+
+//Provides: caml_binaryen_feature_shared_everything
+//Requires: Binaryen
+function caml_binaryen_feature_shared_everything() {
+  return Binaryen.Features.SharedEverything;
+}
+
+//Provides: caml_binaryen_feature_fp16
+//Requires: Binaryen
+function caml_binaryen_feature_fp16() {
+  return Binaryen.Features.FP16;
+}
+
+//Provides: caml_binaryen_feature_bulk_memory_opt
+//Requires: Binaryen
+function caml_binaryen_feature_bulk_memory_opt() {
+  return Binaryen.Features.BulkMemoryOpt;
+}
+
+//Provides: caml_binaryen_feature_call_indirect_overlong
+//Requires: Binaryen
+function caml_binaryen_feature_call_indirect_overlong() {
+  return Binaryen.Features.BulkMemoryOpt;
 }
 
 //Provides: caml_binaryen_feature_all

--- a/test/test.ml
+++ b/test/test.ml
@@ -114,7 +114,7 @@ let start =
 
 let _ = Export.add_function_export wasm_mod "adder" "adder"
 let _ = Table.add_table wasm_mod "table" 1 1 Type.funcref
-let funcref_expr1 = Expression.Ref.func wasm_mod "adder" Type.funcref
+let funcref_expr1 = Expression.Ref.func wasm_mod "adder" (Heap_type.func ())
 
 let _ =
   Expression.Table.set wasm_mod "table"
@@ -265,11 +265,11 @@ let _ =
     [
       Module.Feature.mvp;
       Module.Feature.atomics;
-      Module.Feature.bulk_memory;
       Module.Feature.mutable_globals;
       Module.Feature.nontrapping_fp_to_int;
-      Module.Feature.sign_ext;
       Module.Feature.simd128;
+      Module.Feature.bulk_memory;
+      Module.Feature.sign_ext;
       Module.Feature.exception_handling;
       Module.Feature.tail_call;
       Module.Feature.reference_types;
@@ -280,6 +280,11 @@ let _ =
       Module.Feature.extended_const;
       Module.Feature.strings;
       Module.Feature.multi_memory;
+      Module.Feature.stack_switching;
+      Module.Feature.shared_everything;
+      Module.Feature.fp16;
+      Module.Feature.bulk_memory_opt;
+      Module.Feature.call_indirect_overlong;
       Module.Feature.all;
     ]
 


### PR DESCRIPTION
Full Diff: https://github.com/WebAssembly/binaryen/compare/version_122...version_123

Note: Before this can be merged we need to release libbinaryen v123, and switch the esy package over to the released version.