### PR TITLE
fix!: `Memory.get_segment_byte_offset` on Passive data sections

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -122,9 +122,10 @@ caml_binaryen_get_memory_segment_byte_offset(value _module, value _name) {
   BinaryenModuleRef module = BinaryenModuleRef_val(_module);
   char* name = Safe_String_val(_name);
   if (BinaryenGetMemorySegmentPassive(module, name)) {
-    CAMLreturn(Val_int(-1));
+    CAMLreturn(Val_none);
   } else {
-    CAMLreturn(Val_int(BinaryenGetMemorySegmentByteOffset(module, name)));
+    int offset = BinaryenGetMemorySegmentByteOffset(module, name);
+    CAMLreturn(caml_alloc_some(Val_int(offset)));
   }
 }
 

--- a/src/memory.js
+++ b/src/memory.js
@@ -112,10 +112,10 @@ function caml_binaryen_get_num_memory_segments(wasm_mod) {
 }
 
 //Provides: caml_binaryen_get_memory_segment_byte_offset
-//Requires: caml_jsstring_of_string
+//Requires: caml_jsstring_of_string, to_option
 function caml_binaryen_get_memory_segment_byte_offset(wasm_mod, name) {
   var info = wasm_mod.getMemorySegmentInfo(caml_jsstring_of_string(name));
-  return info.offset;
+  return to_option(info.offset);
 }
 
 //Provides: caml_binaryen_get_memory_segment_passive

--- a/src/memory.ml
+++ b/src/memory.ml
@@ -71,7 +71,7 @@ let unlimited = -1
 external get_num_segments : Module.t -> int
   = "caml_binaryen_get_num_memory_segments"
 
-external get_segment_byte_offset : Module.t -> string -> int
+external get_segment_byte_offset : Module.t -> string -> int option
   = "caml_binaryen_get_memory_segment_byte_offset"
 
 external get_segment_passive : Module.t -> string -> bool

--- a/src/memory.mli
+++ b/src/memory.mli
@@ -20,6 +20,6 @@ val is_shared : Module.t -> string -> bool
 val is_64 : Module.t -> string -> bool
 val unlimited : int
 val get_num_segments : Module.t -> int
-val get_segment_byte_offset : Module.t -> string -> int
+val get_segment_byte_offset : Module.t -> string -> int option
 val get_segment_passive : Module.t -> string -> bool
 val get_segment_data : Module.t -> string -> bytes

--- a/test/test.ml
+++ b/test/test.ml
@@ -249,7 +249,7 @@ let _ = assert (Memory.has_max max_memory_wasm_mod "0" = true)
 let _ = assert (Memory.get_max max_memory_wasm_mod "0" = 2)
 
 (* Memory.get_segment_byte_offset Passive *)
-let _ = assert (Memory.get_segment_byte_offset wasm_mod "world" = -1)
+let _ = assert (Memory.get_segment_byte_offset wasm_mod "world" = None)
 
 let _ =
   assert (


### PR DESCRIPTION
I noticed that `Memory.get_segment_byte_offset` would segfault when you pass in a passive section. I decided to fix this by making it return an option properly, to match up with the `nullish` behaviour of the js api. 

Breaking: This is breaking as we now return an option.