### PR TITLE
fix: Use `caml_uint8_array_of_string` in add_custom_section

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -122,11 +122,11 @@ function caml_binaryen_module_get_debug_info_filename(wasm_mod, index) {
 }
 
 //Provides: caml_binaryen_add_custom_section
-//Requires: caml_jsstring_of_string, caml_array_of_string
+//Requires: caml_jsstring_of_string, caml_uint8_array_of_string
 function caml_binaryen_add_custom_section(wasm_mod, name, contents) {
   return wasm_mod.addCustomSection(
     caml_jsstring_of_string(name),
-    caml_array_of_string(contents)
+    caml_uint8_array_of_string(contents)
   );
 }
 


### PR DESCRIPTION
While working on #265 I noticed that I was getting errors on `caml_binaryen_add_custom_section` as `caml_array_of_string` was deprecated for `caml_uint8_array_of_string` this updates that. The reason this doesn't appear for us is because of our test suite never calls this function.