### PR TITLE
feat!: Upgrade to Binaryen v128

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -16,6 +16,6 @@ depends: [
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.3.0" < "7.0.0"}
-  "libbinaryen" {>= "127.0.0" < "128.0.0"}
+  "libbinaryen" {>= "128.0.0" < "129.0.0"}
 ]
 x-maintenance-intent: ["0.(latest)"]

--- a/binaryen.opam
+++ b/binaryen.opam
@@ -16,6 +16,6 @@ depends: [
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.4.0" < "7.0.0"}
-  "libbinaryen" {>= "127.0.0" < "128.0.0"}
+  "libbinaryen" {>= "128.0.0" < "129.0.0"}
 ]
 x-maintenance-intent: ["0.(latest)"]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cb683f0d62e9f150b764a7ff45bb0fd2",
+  "checksum": "c3ec53b2f6aa254a622a459ddf046e21",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {
@@ -2031,14 +2031,14 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@grain/libbinaryen@127.0.0@d41d8cd9": {
-      "id": "@grain/libbinaryen@127.0.0@d41d8cd9",
+    "@grain/libbinaryen@git:https://github.com/grain-lang/libbinaryen.git#0c23f56e2d0b6d2207bc1b7a7e514881bc9c7816@d41d8cd9": {
+      "id": "@grain/libbinaryen@git:https://github.com/grain-lang/libbinaryen.git#0c23f56e2d0b6d2207bc1b7a7e514881bc9c7816@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "127.0.0",
+      "version": "git:https://github.com/grain-lang/libbinaryen.git#0c23f56e2d0b6d2207bc1b7a7e514881bc9c7816",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-127.0.0.tgz#sha1:ab94716e590c89241c24f690b81b54481cef60cd"
+          "git:https://github.com/grain-lang/libbinaryen.git#0c23f56e2d0b6d2207bc1b7a7e514881bc9c7816"
         ]
       },
       "overrides": [],
@@ -2071,7 +2071,7 @@
         "ocaml@5.3.0@d41d8cd9",
         "@opam/dune-configurator@opam:3.22.1@1e3bb10c",
         "@opam/dune@opam:3.22.1@02acf2a7",
-        "@grain/libbinaryen@127.0.0@d41d8cd9"
+        "@grain/libbinaryen@git:https://github.com/grain-lang/libbinaryen.git#0c23f56e2d0b6d2207bc1b7a7e514881bc9c7816@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.29.0@966c16ee",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a2b1f45014de94318280736834285de9",
+  "checksum": "16257d255d7d1355b780ee3b60243449",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {
@@ -1934,14 +1934,14 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@grain/libbinaryen@127.0.0@d41d8cd9": {
-      "id": "@grain/libbinaryen@127.0.0@d41d8cd9",
+    "@grain/libbinaryen@128.0.0@d41d8cd9": {
+      "id": "@grain/libbinaryen@128.0.0@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "127.0.0",
+      "version": "128.0.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-127.0.0.tgz#sha1:ab94716e590c89241c24f690b81b54481cef60cd"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-128.0.0.tgz#sha1:d2e540a3177f9f6f0f27e6125efdffa5bf670814"
         ]
       },
       "overrides": [],
@@ -1974,7 +1974,7 @@
         "ocaml@5.3.0@d41d8cd9",
         "@opam/dune-configurator@opam:3.24.2@7928eaef",
         "@opam/dune@opam:3.24.2@dc9091c2",
-        "@grain/libbinaryen@127.0.0@d41d8cd9"
+        "@grain/libbinaryen@128.0.0@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.29.0@966c16ee",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ocaml": ">= 4.13.0 < 5.4.0",
-    "@grain/libbinaryen": ">= 127.0.0 < 128.0.0",
+    "@grain/libbinaryen": "*",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"
   },
@@ -19,7 +19,8 @@
     "@opam/ocaml-lsp-server": ">= 1.9.1 < 2.0.0"
   },
   "resolutions": {
-    "@opam/ocp-indent": "1.9.0"
+    "@opam/ocp-indent": "1.9.0",
+    "@grain/libbinaryen": "git+https://github.com/grain-lang/libbinaryen.git#0c23f56e2d0b6d2207bc1b7a7e514881bc9c7816"
   },
   "esy": {
     "build": "dune build -p binaryen"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ocaml": ">= 4.13.0 < 5.4.0",
-    "@grain/libbinaryen": ">= 127.0.0 < 128.0.0",
+    "@grain/libbinaryen": ">= 128.0.0 < 129.0.0",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"
   },


### PR DESCRIPTION
Full Diff: https://github.com/WebAssembly/binaryen/compare/version_127...version_128

NOTE: opam tests will fail until we release libbinaryen and our esy config needs an update once we release libbinaryen