### PR TITLE
feat!: Upgrade to Binaryen v130

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -16,6 +16,6 @@ depends: [
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.4.0" < "7.0.0"}
-  "libbinaryen" {>= "129.0.0" < "130.0.0"}
+  "libbinaryen" {>= "130.0.0" < "131.0.0"}
 ]
 x-maintenance-intent: ["0.(latest)"]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "20ec2a11257be87e1aa8fef3d188392e",
+  "checksum": "a3956e9f0f0cd22bfc47590dd6296579",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {
@@ -1934,14 +1934,14 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@grain/libbinaryen@129.0.0@d41d8cd9": {
-      "id": "@grain/libbinaryen@129.0.0@d41d8cd9",
+    "@grain/libbinaryen@130.0.0@d41d8cd9": {
+      "id": "@grain/libbinaryen@130.0.0@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "129.0.0",
+      "version": "130.0.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-129.0.0.tgz#sha1:6d927815b071a528ee314ad02c3279d86428aec6"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-130.0.0.tgz#sha1:187ebe1390af28043a107dd1a0bc72548234e32a"
         ]
       },
       "overrides": [],
@@ -1974,7 +1974,7 @@
         "ocaml@5.3.0@d41d8cd9",
         "@opam/dune-configurator@opam:3.24.2@7928eaef",
         "@opam/dune@opam:3.24.2@dc9091c2",
-        "@grain/libbinaryen@129.0.0@d41d8cd9"
+        "@grain/libbinaryen@130.0.0@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.29.0@966c16ee",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "ocaml": ">= 4.14.0 < 6.0.0",
-    "@grain/libbinaryen": ">= 129.0.0 < 130.0.0",
+    "@grain/libbinaryen": ">= 130.0.0 < 131.0.0",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"
   },

--- a/src/data_segment.c
+++ b/src/data_segment.c
@@ -9,10 +9,10 @@
 
 
 CAMLprim value
-caml_binaryen_get_num_memory_segments(value _module) {
+caml_binaryen_get_num_data_segments(value _module) {
   CAMLparam1(_module);
   BinaryenModuleRef module = BinaryenModuleRef_val(_module);
-  CAMLreturn(Val_int(BinaryenGetNumMemorySegments(module)));
+  CAMLreturn(Val_int(BinaryenGetNumDataSegments(module)));
 }
 
 CAMLprim value caml_binaryen_get_data_segment(value _module, value _name) {
@@ -43,39 +43,39 @@ CAMLprim value caml_binaryen_data_segment_get_name(value _module, value _segment
 }
 
 CAMLprim value
-caml_binaryen_get_memory_segment_byte_offset(value _module, value _segment) {
+caml_binaryen_get_data_segment_byte_offset(value _module, value _segment) {
   CAMLparam2(_module, _segment);
   BinaryenModuleRef module = BinaryenModuleRef_val(_module);
   BinaryenDataSegmentRef segment = BinaryenDataSegmentRef_val(_segment);
-  if (BinaryenGetMemorySegmentPassive(segment)) {
+  if (BinaryenGetDataSegmentPassive(segment)) {
     CAMLreturn(Val_none);
   } else {
-    int offset = BinaryenGetMemorySegmentByteOffset(module, segment);
+    int offset = BinaryenGetDataSegmentByteOffset(module, segment);
     CAMLreturn(caml_alloc_some(Val_int(offset)));
   }
 }
 
 CAMLprim value
-caml_binaryen_get_memory_segment_byte_length(value _segment) {
+caml_binaryen_get_data_segment_byte_length(value _segment) {
   CAMLparam1(_segment);
   BinaryenDataSegmentRef segment = BinaryenDataSegmentRef_val(_segment);
-  int length = BinaryenGetMemorySegmentByteLength(segment);
+  int length = BinaryenGetDataSegmentByteLength(segment);
   CAMLreturn(Val_int(length));
 }
 
 CAMLprim value
-caml_binaryen_get_memory_segment_passive(value _segment) {
+caml_binaryen_get_data_segment_passive(value _segment) {
   CAMLparam1(_segment);
   BinaryenDataSegmentRef segment = BinaryenDataSegmentRef_val(_segment);
-  CAMLreturn(Val_bool(BinaryenGetMemorySegmentPassive(segment)));
+  CAMLreturn(Val_bool(BinaryenGetDataSegmentPassive(segment)));
 }
 
 CAMLprim value
-caml_binaryen_get_memory_segment_data(value _module, value _segment) {
+caml_binaryen_get_data_segment_data(value _module, value _segment) {
   CAMLparam2(_module, _segment);
   BinaryenDataSegmentRef segment = BinaryenDataSegmentRef_val(_segment);
-  size_t size = BinaryenGetMemorySegmentByteLength(segment);
+  size_t size = BinaryenGetDataSegmentByteLength(segment);
   CAMLprim value bytes = caml_alloc_string(size);
-  BinaryenCopyMemorySegmentData(segment, (char*)Bytes_val(bytes));
+  BinaryenCopyDataSegmentData(segment, (char*)Bytes_val(bytes));
   CAMLreturn(bytes);
 }

--- a/src/data_segment.js
+++ b/src/data_segment.js
@@ -1,7 +1,7 @@
 
-//Provides: caml_binaryen_get_num_memory_segments
-function caml_binaryen_get_num_memory_segments(wasm_mod) {
-  return wasm_mod.getNumMemorySegments();
+//Provides: caml_binaryen_get_num_data_segments
+function caml_binaryen_get_num_data_segments(wasm_mod) {
+  return wasm_mod.getNumDataSegments();
 }
 
 //Provides: caml_binaryen_get_data_segment
@@ -18,32 +18,32 @@ function caml_binaryen_get_data_segment_by_index(wasm_mod, index) {
 // Provides: caml_binaryen_data_segment_get_name
 // Requires: caml_string_of_jsstring
 function caml_binaryen_data_segment_get_name(wasm_mod, segment) {
-  var info = wasm_mod.getMemorySegmentInfo(segment);
+  var info = wasm_mod.getDataSegmentInfo(segment);
   return caml_string_of_jsstring(info.name);
 }
 
-//Provides: caml_binaryen_get_memory_segment_byte_offset
+//Provides: caml_binaryen_get_data_segment_byte_offset
 //Requires: to_option
-function caml_binaryen_get_memory_segment_byte_offset(wasm_mod, segment) {
-  var info = wasm_mod.getMemorySegmentInfo(segment);
+function caml_binaryen_get_data_segment_byte_offset(wasm_mod, segment) {
+  var info = wasm_mod.getDataSegmentInfo(segment);
   return to_option(info.offset);
 }
 
-//Provides: caml_binaryen_get_memory_segment_byte_length
+//Provides: caml_binaryen_get_data_segment_byte_length
 //Requires: Binaryen
-function caml_binaryen_get_memory_segment_byte_length(segment) {
-  return Binaryen._BinaryenGetMemorySegmentByteLength(segment);
+function caml_binaryen_get_data_segment_byte_length(segment) {
+  return Binaryen._BinaryenGetDataSegmentByteLength(segment);
 }
 
-//Provides: caml_binaryen_get_memory_segment_passive
+//Provides: caml_binaryen_get_data_segment_passive
 //Requires: Binaryen
-function caml_binaryen_get_memory_segment_passive(segment) {
-  return Binaryen._BinaryenGetMemorySegmentPassive(segment);
+function caml_binaryen_get_data_segment_passive(segment) {
+  return Binaryen._BinaryenGetDataSegmentPassive(segment);
 }
 
-//Provides: caml_binaryen_get_memory_segment_data
+//Provides: caml_binaryen_get_data_segment_data
 //Requires: caml_bytes_of_array
-function caml_binaryen_get_memory_segment_data(wasm_mod, segment) {
-  var info = wasm_mod.getMemorySegmentInfo(segment);
+function caml_binaryen_get_data_segment_data(wasm_mod, segment) {
+  var info = wasm_mod.getDataSegmentInfo(segment);
   return caml_bytes_of_array(info.data);
 }

--- a/src/data_segment.ml
+++ b/src/data_segment.ml
@@ -1,7 +1,7 @@
 type t
 
 external get_num_segments : Module.t -> int
-  = "caml_binaryen_get_num_memory_segments"
+  = "caml_binaryen_get_num_data_segments"
 
 external get_segment : Module.t -> string -> t option
   = "caml_binaryen_get_data_segment"
@@ -13,13 +13,13 @@ external get_segment_name : Module.t -> t -> string
   = "caml_binaryen_data_segment_get_name"
 
 external get_segment_byte_offset : Module.t -> t -> int option
-  = "caml_binaryen_get_memory_segment_byte_offset"
+  = "caml_binaryen_get_data_segment_byte_offset"
 
 external get_segment_byte_length : t -> int
-  = "caml_binaryen_get_memory_segment_byte_length"
+  = "caml_binaryen_get_data_segment_byte_length"
 
 external get_segment_passive : t -> bool
-  = "caml_binaryen_get_memory_segment_passive"
+  = "caml_binaryen_get_data_segment_passive"
 
 external get_segment_data : Module.t -> t -> bytes
-  = "caml_binaryen_get_memory_segment_data"
+  = "caml_binaryen_get_data_segment_data"

--- a/src/module.ml
+++ b/src/module.ml
@@ -111,6 +111,10 @@ module Feature = struct
 
   let custom_page_sizes = custom_page_sizes ()
 
+  external wide_arithmetic : unit -> t = "caml_binaryen_feature_wide_arithmetic"
+
+  let wide_arithmetic = wide_arithmetic ()
+
   external all : unit -> t = "caml_binaryen_feature_all"
 
   let all = all ()

--- a/src/module.mli
+++ b/src/module.mli
@@ -28,6 +28,7 @@ module Feature : sig
   val relaxed_atomics : t
   val multibyte : t
   val custom_page_sizes : t
+  val wide_arithmetic : t
   val all : t
 end
 

--- a/src/module_feature.c
+++ b/src/module_feature.c
@@ -174,6 +174,12 @@ caml_binaryen_feature_custom_page_sizes(value unit) {
 }
 
 CAMLprim value
+caml_binaryen_feature_wide_arithmetic(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureWideArithmetic()));
+}
+
+CAMLprim value
 caml_binaryen_feature_all(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_int(BinaryenFeatureAll()));

--- a/src/module_feature.js
+++ b/src/module_feature.js
@@ -158,6 +158,12 @@ function caml_binaryen_feature_custom_page_sizes() {
   return Binaryen.Features.CustomPageSizes;
 }
 
+//Provides: caml_binaryen_feature_wide_arithmetic
+//Requires: Binaryen
+function caml_binaryen_feature_wide_arithmetic() {
+  return Binaryen.Features.WideArithmetic;
+}
+
 //Provides: caml_binaryen_feature_all
 //Requires: Binaryen
 function caml_binaryen_feature_all() {

--- a/src/op.c
+++ b/src/op.c
@@ -903,6 +903,34 @@ caml_binaryen_ge_float64(value unit) {
 }
 
 CAMLprim value
+caml_binaryen_add_int128(value unit) {
+  CAMLparam1(unit);
+  BinaryenOp op = BinaryenAddInt128();
+  CAMLreturn(alloc_BinaryenOp(op));
+}
+
+CAMLprim value
+caml_binaryen_sub_int128(value unit) {
+  CAMLparam1(unit);
+  BinaryenOp op = BinaryenSubInt128();
+  CAMLreturn(alloc_BinaryenOp(op));
+}
+
+CAMLprim value
+caml_binaryen_mul_wide_sint64(value unit) {
+  CAMLparam1(unit);
+  BinaryenOp op = BinaryenMulWideSInt64();
+  CAMLreturn(alloc_BinaryenOp(op));
+}
+
+CAMLprim value
+caml_binaryen_mul_wide_uint64(value unit) {
+  CAMLparam1(unit);
+  BinaryenOp op = BinaryenMulWideUInt64();
+  CAMLreturn(alloc_BinaryenOp(op));
+}
+
+CAMLprim value
 caml_binaryen_atomic_rmw_add(value unit) {
   CAMLparam1(unit);
   BinaryenOp op = BinaryenAtomicRMWAdd();
@@ -1505,37 +1533,37 @@ caml_binaryen_relaxed_nmadd_vec_f64x4(value unit) {
 }
 
 CAMLprim value
-caml_binaryen_laneselect_i8x16(value unit) {
+caml_binaryen_relaxed_laneselect_i8x16(value unit) {
   CAMLparam1(unit);
-  BinaryenOp op = BinaryenLaneselectI8x16();
+  BinaryenOp op = BinaryenRelaxedLaneselectI8x16();
   CAMLreturn(alloc_BinaryenOp(op));
 }
 
 CAMLprim value
-caml_binaryen_laneselect_i16x8(value unit) {
+caml_binaryen_relaxed_laneselect_i16x8(value unit) {
   CAMLparam1(unit);
-  BinaryenOp op = BinaryenLaneselectI16x8();
+  BinaryenOp op = BinaryenRelaxedLaneselectI16x8();
   CAMLreturn(alloc_BinaryenOp(op));
 }
 
 CAMLprim value
-caml_binaryen_laneselect_i32x4(value unit) {
+caml_binaryen_relaxed_laneselect_i32x4(value unit) {
   CAMLparam1(unit);
-  BinaryenOp op = BinaryenLaneselectI32x4();
+  BinaryenOp op = BinaryenRelaxedLaneselectI32x4();
   CAMLreturn(alloc_BinaryenOp(op));
 }
 
 CAMLprim value
-caml_binaryen_laneselect_i64x2(value unit) {
+caml_binaryen_relaxed_laneselect_i64x2(value unit) {
   CAMLparam1(unit);
-  BinaryenOp op = BinaryenLaneselectI64x2();
+  BinaryenOp op = BinaryenRelaxedLaneselectI64x2();
   CAMLreturn(alloc_BinaryenOp(op));
 }
 
 CAMLprim value
-caml_binaryen_dot_i8x16_i7x16_add_s_to_vec_i32x4(value unit) {
+caml_binaryen_relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4(value unit) {
   CAMLparam1(unit);
-  BinaryenOp op = BinaryenDotI8x16I7x16AddSToVecI32x4();
+  BinaryenOp op = BinaryenRelaxedDotI8x16I7x16AddSToVecI32x4();
   CAMLreturn(alloc_BinaryenOp(op));
 }
 
@@ -2236,6 +2264,13 @@ CAMLprim value
 caml_binaryen_swizzle_vec8x16(value unit) {
   CAMLparam1(unit);
   BinaryenOp op = BinaryenSwizzleVecI8x16();
+  CAMLreturn(alloc_BinaryenOp(op));
+}
+
+CAMLprim value
+caml_binaryen_relaxed_dot_i8x16_i7x16_s_to_vec_i16x8(value unit) {
+  CAMLparam1(unit);
+  BinaryenOp op = BinaryenRelaxedDotI8x16I7x16SToVecI16x8();
   CAMLreturn(alloc_BinaryenOp(op));
 }
 

--- a/src/op.js
+++ b/src/op.js
@@ -766,6 +766,30 @@ function caml_binaryen_ge_float64() {
   return Binaryen.Operations.GeFloat64;
 }
 
+//Provides: caml_binaryen_add_int128
+//Requires: Binaryen
+function caml_binaryen_add_int128() {
+  return Binaryen.Operations.AddInt128;
+}
+
+//Provides: caml_binaryen_sub_int128
+//Requires: Binaryen
+function caml_binaryen_sub_int128() {
+  return Binaryen.Operations.SubInt128;
+}
+
+//Provides: caml_binaryen_mul_wide_sint64
+//Requires: Binaryen
+function caml_binaryen_mul_wide_sint64() {
+  return Binaryen.Operations.MulWideSInt64;
+}
+
+//Provides: caml_binaryen_mul_wide_uint64
+//Requires: Binaryen
+function caml_binaryen_mul_wide_uint64() {
+  return Binaryen.Operations.MulWideUInt64;
+}
+
 //Provides: caml_binaryen_atomic_rmw_add
 //Requires: Binaryen
 function caml_binaryen_atomic_rmw_add() {
@@ -1282,34 +1306,34 @@ function caml_binaryen_relaxed_nmadd_vec_f64x4() {
   return Binaryen.Operations.RelaxedNmaddVecF64x2;
 }
 
-//Provides: caml_binaryen_laneselect_i8x16
+//Provides: caml_binaryen_relaxed_laneselect_i8x16
 //Requires: Binaryen
-function caml_binaryen_laneselect_i8x16() {
-  return Binaryen.Operations.LaneselectI8x16;
+function caml_binaryen_relaxed_laneselect_i8x16() {
+  return Binaryen.Operations.RelaxedLaneselectI8x16;
 }
 
-//Provides: caml_binaryen_laneselect_i16x8
+//Provides: caml_binaryen_relaxed_laneselect_i16x8
 //Requires: Binaryen
-function caml_binaryen_laneselect_i16x8() {
-  return Binaryen.Operations.LaneselectI16x8;
+function caml_binaryen_relaxed_laneselect_i16x8() {
+  return Binaryen.Operations.RelaxedLaneselectI16x8;
 }
 
-//Provides: caml_binaryen_laneselect_i32x4
+//Provides: caml_binaryen_relaxed_laneselect_i32x4
 //Requires: Binaryen
-function caml_binaryen_laneselect_i32x4() {
-  return Binaryen.Operations.LaneselectI32x4;
+function caml_binaryen_relaxed_laneselect_i32x4() {
+  return Binaryen.Operations.RelaxedLaneselectI32x4;
 }
 
-//Provides: caml_binaryen_laneselect_i64x2
+//Provides: caml_binaryen_relaxed_laneselect_i64x2
 //Requires: Binaryen
-function caml_binaryen_laneselect_i64x2() {
-  return Binaryen.Operations.LaneselectI64x2;
+function caml_binaryen_relaxed_laneselect_i64x2() {
+  return Binaryen.Operations.RelaxedLaneselectI64x2;
 }
 
-//Provides: caml_binaryen_dot_i8x16_i7x16_add_s_to_vec_i32x4
+//Provides: caml_binaryen_relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4
 //Requires: Binaryen
-function caml_binaryen_dot_i8x16_i7x16_add_s_to_vec_i32x4() {
-  return Binaryen.Operations.DotI8x16I7x16AddSToVecI32x4;
+function caml_binaryen_relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4() {
+  return Binaryen.Operations.RelaxedDotI8x16I7x16AddSToVecI32x4;
 }
 
 //Provides: caml_binaryen_any_true_vec128
@@ -1910,6 +1934,12 @@ function caml_binaryen_narrow_u_vec_i32x4_to_vec_i16x8() {
 //Requires: Binaryen
 function caml_binaryen_swizzle_vec8x16() {
   return Binaryen.Operations.SwizzleVecI8x16;
+}
+
+//Provides: caml_binaryen_relaxed_dot_i8x16_i7x16_s_to_vec_i16x8
+//Requires: Binaryen
+function caml_binaryen_relaxed_dot_i8x16_i7x16_s_to_vec_i16x8() {
+  return Binaryen.Operations.RelaxedDotI8x16I7x16SToVecI16x8;
 }
 
 //Provides: caml_binaryen_ref_as_non_null

--- a/src/op.ml
+++ b/src/op.ml
@@ -528,6 +528,22 @@ external ge_float64 : unit -> t = "caml_binaryen_ge_float64"
 
 let ge_float64 = ge_float64 ()
 
+external add_int128 : unit -> t = "caml_binaryen_add_int128"
+
+let add_int128 = add_int128 ()
+
+external sub_int128 : unit -> t = "caml_binaryen_sub_int128"
+
+let sub_int128 = sub_int128 ()
+
+external mul_wide_sint64 : unit -> t = "caml_binaryen_mul_wide_sint64"
+
+let mul_wide_sint64 = mul_wide_sint64 ()
+
+external mul_wide_uint64 : unit -> t = "caml_binaryen_mul_wide_uint64"
+
+let mul_wide_uint64 = mul_wide_uint64 ()
+
 external atomic_rmw_add : unit -> t = "caml_binaryen_atomic_rmw_add"
 
 let atomic_rmw_add = atomic_rmw_add ()
@@ -898,26 +914,31 @@ external relaxed_nmadd_vec_f64x4 : unit -> t
 
 let relaxed_nmadd_vec_f64x4 = relaxed_nmadd_vec_f64x4 ()
 
-external laneselect_i8x16 : unit -> t = "caml_binaryen_laneselect_i8x16"
+external relaxed_laneselect_i8x16 : unit -> t
+  = "caml_binaryen_relaxed_laneselect_i8x16"
 
-let laneselect_i8x16 = laneselect_i8x16 ()
+let relaxed_laneselect_i8x16 = relaxed_laneselect_i8x16 ()
 
-external laneselect_i16x8 : unit -> t = "caml_binaryen_laneselect_i16x8"
+external relaxed_laneselect_i16x8 : unit -> t
+  = "caml_binaryen_relaxed_laneselect_i16x8"
 
-let laneselect_i16x8 = laneselect_i16x8 ()
+let relaxed_laneselect_i16x8 = relaxed_laneselect_i16x8 ()
 
-external laneselect_i32x4 : unit -> t = "caml_binaryen_laneselect_i32x4"
+external relaxed_laneselect_i32x4 : unit -> t
+  = "caml_binaryen_relaxed_laneselect_i32x4"
 
-let laneselect_i32x4 = laneselect_i32x4 ()
+let relaxed_laneselect_i32x4 = relaxed_laneselect_i32x4 ()
 
-external laneselect_i64x2 : unit -> t = "caml_binaryen_laneselect_i64x2"
+external relaxed_laneselect_i64x2 : unit -> t
+  = "caml_binaryen_relaxed_laneselect_i64x2"
 
-let laneselect_i64x2 = laneselect_i64x2 ()
+let relaxed_laneselect_i64x2 = relaxed_laneselect_i64x2 ()
 
-external dot_i8x16_i7x16_add_s_to_vec_i32x4 : unit -> t
-  = "caml_binaryen_dot_i8x16_i7x16_add_s_to_vec_i32x4"
+external relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4 : unit -> t
+  = "caml_binaryen_relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4"
 
-let dot_i8x16_i7x16_add_s_to_vec_i32x4 = dot_i8x16_i7x16_add_s_to_vec_i32x4 ()
+let relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4 =
+  relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4 ()
 
 external any_true_vec128 : unit -> t = "caml_binaryen_any_true_vec128"
 
@@ -1327,6 +1348,12 @@ let narrow_u_vec_i32x4_to_vec_i16x8 = narrow_u_vec_i32x4_to_vec_i16x8 ()
 external swizzle_vec8x16 : unit -> t = "caml_binaryen_swizzle_vec8x16"
 
 let swizzle_vec8x16 = swizzle_vec8x16 ()
+
+external relaxed_dot_i8x16_i7x16_s_to_vec_i16x8 : unit -> t
+  = "caml_binaryen_relaxed_dot_i8x16_i7x16_s_to_vec_i16x8"
+
+let relaxed_dot_i8x16_i7x16_s_to_vec_i16x8 =
+  relaxed_dot_i8x16_i7x16_s_to_vec_i16x8 ()
 
 external ref_as_non_null : unit -> t = "caml_binaryen_ref_as_non_null"
 

--- a/src/op.mli
+++ b/src/op.mli
@@ -128,6 +128,10 @@ val lt_float64 : t
 val le_float64 : t
 val gt_float64 : t
 val ge_float64 : t
+val add_int128 : t
+val sub_int128 : t
+val mul_wide_sint64 : t
+val mul_wide_uint64 : t
 val atomic_rmw_add : t
 val atomic_rmw_sub : t
 val atomic_rmw_and : t
@@ -214,11 +218,11 @@ val relaxed_madd_vec_f32x4 : t
 val relaxed_nmadd_vec_f32x4 : t
 val relaxed_madd_vec_f64x4 : t
 val relaxed_nmadd_vec_f64x4 : t
-val laneselect_i8x16 : t
-val laneselect_i16x8 : t
-val laneselect_i32x4 : t
-val laneselect_i64x2 : t
-val dot_i8x16_i7x16_add_s_to_vec_i32x4 : t
+val relaxed_laneselect_i8x16 : t
+val relaxed_laneselect_i16x8 : t
+val relaxed_laneselect_i32x4 : t
+val relaxed_laneselect_i64x2 : t
+val relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4 : t
 val any_true_vec128 : t
 val popcnt_vec_i8x16 : t
 val abs_vec_i8x16 : t
@@ -319,6 +323,7 @@ val narrow_u_vec_i16x8_to_vec_i8x16 : t
 val narrow_s_vec_i32x4_to_vec_i16x8 : t
 val narrow_u_vec_i32x4_to_vec_i16x8 : t
 val swizzle_vec8x16 : t
+val relaxed_dot_i8x16_i7x16_s_to_vec_i16x8 : t
 val ref_as_non_null : t
 val ref_as_extern_internalize : t
 val ref_as_extern_externalize : t

--- a/src/passes.ml
+++ b/src/passes.ml
@@ -191,6 +191,9 @@ let licm = "licm"
 (** attempt to merge segments to fit within web limits *)
 let limit_segments = "limit-segments"
 
+(** mark js called functions (using configureAll) as doing so *)
+let mark_js_called = "mark-js-called"
+
 (** lower loads and stores to a 64-bit memory to instead use a 32-bit one *)
 let memory64_lowering = "memory64-lowering"
 
@@ -312,6 +315,9 @@ let print_features = "print-features"
 (** print in full s-expression format *)
 let print_full = "print-full"
 
+(** print boundary in JSON format *)
+let print_boundary = "print-boundary"
+
 (** print call graph *)
 let print_call_graph = "print-call-graph"
 
@@ -326,6 +332,9 @@ let remove_non_js_ops = "remove-non-js-ops"
 
 (** replaces relaxed SIMD instructions with unreachable *)
 let remove_relaxed_simd = "remove-relaxed-simd"
+
+(** removes exports using a wildcard *)
+let remove_exports = "remove-exports"
 
 (** removes imports and replaces them with nops *)
 let remove_imports = "remove-imports"

--- a/src/passes.mli
+++ b/src/passes.mli
@@ -188,6 +188,9 @@ val licm : t
 val limit_segments : t
 (** attempt to merge segments to fit within web limits *)
 
+val mark_js_called : t
+(** mark js called functions (using configureAll) as doing so *)
+
 val memory64_lowering : t
 (** lower loads and stores to a 64-bit memory to instead use a 32-bit one *)
 
@@ -280,7 +283,7 @@ val pick_load_signs : t
 (** pick load signs based on their uses *)
 
 val poppify : t
-(** Tranform Binaryen IR into Poppy IR *)
+(** Transform Binaryen IR into Poppy IR *)
 
 val post_emscripten : t
 (** miscellaneous optimizations for Emscripten-generated code *)
@@ -307,6 +310,9 @@ val print_features : t
 val print_full : t
 (** print in full s-expression format *)
 
+val print_boundary : t
+(** print boundary in JSON format *)
+
 val print_call_graph : t
 (** print call graph *)
 
@@ -321,6 +327,9 @@ val remove_non_js_ops : t
 
 val remove_relaxed_simd : t
 (** replaces relaxed SIMD instructions with unreachable *)
+
+val remove_exports : t
+(** removes exports using a wildcard *)
 
 val remove_imports : t
 (** removes imports and replaces them with nops *)


### PR DESCRIPTION
Full Diff: https://github.com/WebAssembly/binaryen/compare/version_129...version_130

API Additions:
* Module.Feature.WideArithmetic
* Op.add_int128
* Op.sub_int128
* Op.mul_wide_sint64
* Op.mul_wide_uint64
* Op.relaxed_laneselect_i8x16
* Op.relaxed_laneselect_i16x8
* Op.relaxed_laneselect_i32x4
* Op.relaxed_laneselect_i64x2
* Op.relaxed_dot_i8x16_i7x16_add_s_to_vec_i32x4
* Op.relaxed_dot_i8x16_i7x16_s_to_vec_i16x8
* Passes.mark_js_called
* Passes.print_boundary
* Passes.remove_exports

API Removals:
* Op.laneselect_i8x16
* Op.laneselect_i16x8
* Op.laneselect_i32x4
* Op.laneselect_i64x2
* Op.dot_i8x16_i7x16_add_s_to_vec_i32x4

Changes not made:
* BinaryenPromoteLowVecF16x8ToVecF32x4: was not added as it was not added to the js api
* BinaryenWide functions as this is probably best done in it's own pr given it's an entirely new api, we should probably open an issue for these however

NOTE: This is blocked on libbinaryen v130 releasing