### PR TITLE
feat!: Upgrade to Binaryen v131

### DIFF
--- a/binaryen.opam
+++ b/binaryen.opam
@@ -16,6 +16,6 @@ depends: [
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.4.0" < "7.0.0"}
-  "libbinaryen" {>= "130.0.0" < "131.0.0"}
+  "libbinaryen" {>= "131.0.0" < "132.0.0"}
 ]
 x-maintenance-intent: ["0.(latest)"]

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a3956e9f0f0cd22bfc47590dd6296579",
+  "checksum": "cb86c36eb2efb63fbf47f7c5ea9f87b9",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {
@@ -1934,14 +1934,14 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@grain/libbinaryen@130.0.0@d41d8cd9": {
-      "id": "@grain/libbinaryen@130.0.0@d41d8cd9",
+    "@grain/libbinaryen@131.0.0@d41d8cd9": {
+      "id": "@grain/libbinaryen@131.0.0@d41d8cd9",
       "name": "@grain/libbinaryen",
-      "version": "130.0.0",
+      "version": "131.0.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-130.0.0.tgz#sha1:187ebe1390af28043a107dd1a0bc72548234e32a"
+          "archive:https://registry.npmjs.org/@grain/libbinaryen/-/libbinaryen-131.0.0.tgz#sha1:a1fb1fd1c0b87fcc277e19835220ec450f199605"
         ]
       },
       "overrides": [],
@@ -1974,7 +1974,7 @@
         "ocaml@5.3.0@d41d8cd9",
         "@opam/dune-configurator@opam:3.24.2@7928eaef",
         "@opam/dune@opam:3.24.2@dc9091c2",
-        "@grain/libbinaryen@130.0.0@d41d8cd9"
+        "@grain/libbinaryen@131.0.0@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.29.0@966c16ee",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "ocaml": ">= 4.14.0 < 6.0.0",
-    "@grain/libbinaryen": ">= 130.0.0 < 131.0.0",
+    "@grain/libbinaryen": ">= 131.0.0 < 132.0.0",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"
   },

--- a/src/module.c
+++ b/src/module.c
@@ -29,6 +29,16 @@ caml_binaryen_module_parse(value _text) {
   CAMLreturn(alloc_BinaryenModuleRef(module));
 }
 
+
+CAMLprim value
+caml_binaryen_module_parse_with_features(value _text, value _features) {
+  CAMLparam2(_text, _features);
+  const char* text = Safe_String_val(_text);
+  BinaryenFeatures features = Int_val(_features);
+  BinaryenModuleRef module = BinaryenModuleParseWithFeatures(text, features);
+  CAMLreturn(alloc_BinaryenModuleRef(module));
+}
+
 CAMLprim value
 caml_binaryen_module_print(value module) {
   CAMLparam1(module);

--- a/src/module.js
+++ b/src/module.js
@@ -16,6 +16,13 @@ function caml_binaryen_module_parse(text) {
   return Binaryen.parseText(caml_jsstring_of_string(text));
 }
 
+//Provides: caml_binaryen_module_parse_with_features
+//Requires: Binaryen
+//Requires: caml_jsstring_of_string
+function caml_binaryen_module_parse_with_features(text, features) {
+  return Binaryen.parseText(caml_jsstring_of_string(text), features);
+}
+
 //Provides: caml_binaryen_module_print
 //Requires: caml_ml_output_str_stdout
 function caml_binaryen_module_print(wasm_mod) {

--- a/src/module.ml
+++ b/src/module.ml
@@ -115,6 +115,10 @@ module Feature = struct
 
   let wide_arithmetic = wide_arithmetic ()
 
+  external compact_imports : unit -> t = "caml_binaryen_feature_compact_imports"
+
+  let compact_imports = compact_imports ()
+
   external all : unit -> t = "caml_binaryen_feature_all"
 
   let all = all ()
@@ -127,6 +131,10 @@ external add_custom_section : t -> string -> string -> unit
   = "caml_binaryen_add_custom_section"
 
 external parse : string -> t = "caml_binaryen_module_parse"
+
+external parse_with_features : string -> Feature.t -> t
+  = "caml_binaryen_module_parse_with_features"
+
 external print : t -> unit = "caml_binaryen_module_print"
 external print_asmjs : t -> unit = "caml_binaryen_module_print_asmjs"
 external print_stack_ir : t -> unit = "caml_binaryen_module_print_stack_ir"

--- a/src/module.mli
+++ b/src/module.mli
@@ -29,6 +29,7 @@ module Feature : sig
   val multibyte : t
   val custom_page_sizes : t
   val wide_arithmetic : t
+  val compact_imports : t
   val all : t
 end
 
@@ -36,6 +37,7 @@ val create : unit -> t
 val dispose : t -> unit
 val add_custom_section : t -> string -> string -> unit
 val parse : string -> t
+val parse_with_features : string -> Feature.t -> t
 val print : t -> unit
 val print_asmjs : t -> unit
 val print_stack_ir : t -> unit

--- a/src/module_feature.c
+++ b/src/module_feature.c
@@ -180,6 +180,12 @@ caml_binaryen_feature_wide_arithmetic(value unit) {
 }
 
 CAMLprim value
+caml_binaryen_feature_compact_imports(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_int(BinaryenFeatureCompactImports()));
+}
+
+CAMLprim value
 caml_binaryen_feature_all(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_int(BinaryenFeatureAll()));

--- a/src/module_feature.js
+++ b/src/module_feature.js
@@ -164,6 +164,12 @@ function caml_binaryen_feature_wide_arithmetic() {
   return Binaryen.Features.WideArithmetic;
 }
 
+//Provides: caml_binaryen_feature_compact_imports
+//Requires: Binaryen
+function caml_binaryen_feature_compact_imports() {
+  return Binaryen.Features.CompactImports;
+}
+
 //Provides: caml_binaryen_feature_all
 //Requires: Binaryen
 function caml_binaryen_feature_all() {

--- a/src/passes.ml
+++ b/src/passes.ml
@@ -43,6 +43,9 @@ let cfp = "cfp"
 (** propagate constant struct field values, using ref.test *)
 let cfp_reftest = "cfp-reftest"
 
+(** finds and uses mathematical constraints on locals *)
+let constraint_analysis = "constraint-analysis"
+
 (** removes unreachable code *)
 let dce = "dce"
 

--- a/src/passes.mli
+++ b/src/passes.mli
@@ -43,6 +43,9 @@ val cfp : t
 val cfp_reftest : t
 (** propagate constant struct field values, using ref.test *)
 
+val constraint_analysis : t
+(** finds and uses mathematical constraints on locals *)
+
 val dce : t
 (** removes unreachable code *)
 


### PR DESCRIPTION
Full Diff: https://github.com/WebAssembly/binaryen/compare/version_130...version_131

API Additions:
* Module.Feature.compact_imports
* Module.parse_with_features
* Passes.constraint_analysis

Changes not made:
* BinaryenAtomicFence & BinaryenAtomicFenceGetOrder were modified however we do not currently have bindings for atomic apis.

NOTE: This is blocked on libbinaryen v131 releasing