### PR TITLE
feat!: drop support for ocaml 4

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ocaml-compiler: [4.13.1, 4.14.1, 5.3.0]
+        ocaml-compiler: [5.3.0]
 
     steps:
       - name: Checkout project

--- a/binaryen.opam
+++ b/binaryen.opam
@@ -12,7 +12,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.13.0"}
+  "ocaml" {>= "5.0.0" < "6.0.0"}
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.4.0" < "7.0.0"}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5c222c1460a4598620ddef56248bc82f",
+  "checksum": "6eb75213a0479ce9760e2dcd73b29b30",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {
@@ -968,7 +968,7 @@
         "@opam/dune-rpc@opam:3.20.2@c55481ce",
         "@opam/dune-build-info@opam:3.24.2@e3506498",
         "@opam/dune@opam:3.24.2@dc9091c2", "@opam/csexp@opam:1.5.2@46614bf4",
-        "@opam/chrome-trace@opam:3.24.1@98879dd0",
+        "@opam/chrome-trace@opam:3.24.2@cd44885b",
         "@opam/camlp-streams@opam:5.0.1@8e96208c",
         "@opam/base@opam:v0.17.3@1b4d501e",
         "@opam/astring@opam:0.8.5@9975798d",
@@ -991,7 +991,7 @@
         "@opam/dune-rpc@opam:3.20.2@c55481ce",
         "@opam/dune-build-info@opam:3.24.2@e3506498",
         "@opam/dune@opam:3.24.2@dc9091c2", "@opam/csexp@opam:1.5.2@46614bf4",
-        "@opam/chrome-trace@opam:3.24.1@98879dd0",
+        "@opam/chrome-trace@opam:3.24.2@cd44885b",
         "@opam/camlp-streams@opam:5.0.1@8e96208c",
         "@opam/base@opam:v0.17.3@1b4d501e",
         "@opam/astring@opam:0.8.5@9975798d"
@@ -1759,20 +1759,20 @@
         [ "windows", "x86_64" ]
       ]
     },
-    "@opam/chrome-trace@opam:3.24.1@98879dd0": {
-      "id": "@opam/chrome-trace@opam:3.24.1@98879dd0",
+    "@opam/chrome-trace@opam:3.24.2@cd44885b": {
+      "id": "@opam/chrome-trace@opam:3.24.2@cd44885b",
       "name": "@opam/chrome-trace",
-      "version": "opam:3.24.1",
+      "version": "opam:3.24.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/0a/0a8eaa62dfcb945802bcaf9a6f2026ca5228333ee391a1bdedd3e70a3f26ea2c#sha256:0a8eaa62dfcb945802bcaf9a6f2026ca5228333ee391a1bdedd3e70a3f26ea2c",
-          "archive:https://github.com/ocaml/dune/releases/download/3.24.1/dune-3.24.1.tbz#sha256:0a8eaa62dfcb945802bcaf9a6f2026ca5228333ee391a1bdedd3e70a3f26ea2c"
+          "archive:https://opam.ocaml.org/cache/sha256/47/472798691b0216daf538709f0f4703b3617ef24ad0866c9096068baaba4d762a#sha256:472798691b0216daf538709f0f4703b3617ef24ad0866c9096068baaba4d762a",
+          "archive:https://github.com/ocaml/dune/releases/download/3.24.2/dune-3.24.2.tbz#sha256:472798691b0216daf538709f0f4703b3617ef24ad0866c9096068baaba4d762a"
         ],
         "opam": {
           "name": "chrome-trace",
-          "version": "3.24.1",
-          "path": "esy.lock/opam/chrome-trace.3.24.1"
+          "version": "3.24.2",
+          "path": "esy.lock/opam/chrome-trace.3.24.2"
         }
       },
       "overrides": [],

--- a/esy.lock/opam/chrome-trace.3.24.2/opam
+++ b/esy.lock/opam/chrome-trace.3.24.2/opam
@@ -30,10 +30,10 @@ build: [
 ]
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.24.1/dune-3.24.1.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.24.2/dune-3.24.2.tbz"
   checksum: [
-    "sha256=0a8eaa62dfcb945802bcaf9a6f2026ca5228333ee391a1bdedd3e70a3f26ea2c"
-    "sha512=b9faebfa70cf87e5eb582a0cdd1cb2aa99b8195342afdd7f462365444a0a904819cacc8522a5a85800ed2281f84e82d49360010de7ff16e28047a74df9258e5e"
+    "sha256=472798691b0216daf538709f0f4703b3617ef24ad0866c9096068baaba4d762a"
+    "sha512=13082a66a28e940d4b3c9f78b556f6c1455987cd522355ba4502e01e60a3d002d3101b51284726ae21aa87494efa2dc54d016173f05b616bbc5dad714d5714a3"
   ]
 }
-x-commit-hash: "a5d7d322823927dd5d85ae102fd7d442be2f7e66"
+x-commit-hash: "ce734ac25ffb06994a4530426bb06ee8cda19e50"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pnp": false
   },
   "dependencies": {
-    "ocaml": ">= 4.13.0 < 5.4.0",
+    "ocaml": ">= 5.0.0 < 5.4.0",
     "@grain/libbinaryen": ">= 126.0.0 < 127.0.0",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"


### PR DESCRIPTION
Ocaml 5 came out in 2022, and has been adopted by most of the community as far as we are aware there are no consumers using ocaml 4, so dropping support seems sensible so we can focus on supporting ocaml 5.

This drops our testing requirements to only ocaml 5 saving quite a bit of ci time.