### PR TITLE
chore: Switch release ci from mac to ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,14 @@ jobs:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.release_created }}
     name: Add archive to release
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       browser_download_url: ${{ steps.upload.outputs.browser_download_url }}
       notes: ${{ steps.upload.outputs.notes }}
     steps:
       - name: Install git-archive-all
         run: |
-          brew install git-archive-all
+          pipx install git-archive-all
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This pr switches the archive process in our release pipeline from running on macos to running on ubuntu.

A test to ensure we are getting the same result from the archive can be found here: https://github.com/grain-lang/binaryen.ml/actions/runs/33789411705 

Closes: #159