### PR TITLE
feat!: Drop ocaml 4.13 support

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ocaml-compiler: [4.13.1, 4.14.1, 5.3.0]
+        ocaml-compiler: [4.14.1, 5.3.0]
 
     steps:
       - name: Checkout project

--- a/binaryen.opam
+++ b/binaryen.opam
@@ -12,7 +12,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.13.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {>= "6.4.0" < "7.0.0"}

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "16257d255d7d1355b780ee3b60243449",
+  "checksum": "e0ac1b977a50c857edf45c8c6b5c6a02",
   "root": "@grain/binaryen.ml@link-dev:./package.json",
   "node": {
     "ocaml@5.3.0@d41d8cd9": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pnp": false
   },
   "dependencies": {
-    "ocaml": ">= 4.13.0 < 5.4.0",
+    "ocaml": ">= 4.14.0 < 6.0.0",
     "@grain/libbinaryen": ">= 128.0.0 < 129.0.0",
     "@opam/dune": ">= 3.0.0",
     "@opam/dune-configurator": ">= 3.0.0"


### PR DESCRIPTION
This pr drops ocaml 4.13 support, this removes 1 runner for each commit which should save some ci time.

The decision to drop support was made in part because:
* opam doesn't test anything below 4.14
* ocaml-setup requires a version greater than 4.14 when we upgrade
* We are debating dropping ocaml 4 altogether